### PR TITLE
Skip Python ZIP Applications when patching args

### DIFF
--- a/pydev_monkey.py
+++ b/pydev_monkey.py
@@ -88,6 +88,26 @@ def patch_args(args):
                     new_args[indC + 1] = _get_python_c_args(host, port, indC, args)
                     return new_args
             else:
+                # Check for Python ZIP Applications and don't patch the args for them.
+                # Assumes the first non `-<flag>` argument is what we need to check.
+                # There's probably a better way to determine this but it works for most cases.
+                continue_next = False
+                for i in range(1, len(args)):
+                    if continue_next:
+                        continue_next = False
+                        continue
+
+                    arg = args[i]
+                    if arg.startswith('-'):
+                        # Skip the next arg too if this flag expects a value.
+                        continue_next = arg in ['-m', '-W', '-X']
+                        continue
+
+                    if arg.rsplit('.')[-1] in ['zip', 'pyz', 'pyzw']:
+                        pydev_log.debug('Executing a PyZip, returning')
+                        return args
+                    break
+
                 new_args.append(args[0])
         else:
             log_debug("Process is not python, returning.")


### PR DESCRIPTION
PyZipApps break the debugger when they're executed from another Python process (and they're hard to debug anyway):

```
SyntaxError: invalid or missing encoding declaration for '/path/to/pyzipapp.zip'
```
Do a quick check on the arguments to see if there's a `.zip`, `.pyz`, or `.pyzw` file being executed and return if there is.

PyCharm issue: https://youtrack.jetbrains.com/issue/PY-16568