### PR TITLE
Allow client program to edit paths

### DIFF
--- a/_pydevd_bundle/pydevd_process_net_command.py
+++ b/_pydevd_bundle/pydevd_process_net_command.py
@@ -4,7 +4,7 @@ import traceback
 
 from _pydev_bundle import pydev_log
 from _pydevd_bundle import pydevd_traceproperty, pydevd_tracing, pydevd_dont_trace
-from pydevd_file_utils import norm_file_to_server
+import pydevd_file_utils
 from _pydevd_bundle.pydevd_breakpoints import LineBreakpoint, update_exception_hook
 from _pydevd_bundle.pydevd_comm import CMD_RUN, CMD_VERSION, CMD_LIST_THREADS, CMD_THREAD_KILL, InternalTerminateThread, \
     CMD_THREAD_SUSPEND, pydevd_find_thread_by_id, CMD_THREAD_RUN, InternalRunThread, CMD_STEP_INTO, CMD_STEP_OVER, \
@@ -255,7 +255,7 @@ def process_net_command(py_db, cmd_id, seq, text):
                 if not IS_PY3K:  # In Python 3, the frame object will have unicode for the file, whereas on python 2 it has a byte-array encoded with the filesystem encoding.
                     file = file.encode(file_system_encoding)
 
-                file = norm_file_to_server(file)
+                file = pydevd_file_utils.norm_file_to_server(file)
 
                 if not pydevd_file_utils.exists(file):
                     sys.stderr.write('pydev debugger: warning: trying to add breakpoint'\
@@ -314,7 +314,7 @@ def process_net_command(py_db, cmd_id, seq, text):
                 if not IS_PY3K:  # In Python 3, the frame object will have unicode for the file, whereas on python 2 it has a byte-array encoded with the filesystem encoding.
                     file = file.encode(file_system_encoding)
 
-                file = norm_file_to_server(file)
+                file = pydevd_file_utils.norm_file_to_server(file)
 
                 try:
                     breakpoint_id = int(breakpoint_id)
@@ -622,7 +622,7 @@ def process_net_command(py_db, cmd_id, seq, text):
                             if not IS_PY3K:
                                 filename = filename.encode(file_system_encoding)
 
-                            filename = norm_file_to_server(filename)
+                            filename = pydevd_file_utils.norm_file_to_server(filename)
 
                             if os.path.exists(filename):
                                 lines_ignored = py_db.filename_to_lines_where_exceptions_are_ignored.get(filename)

--- a/pydevd_file_utils.py
+++ b/pydevd_file_utils.py
@@ -231,8 +231,28 @@ except:
     #Don't fail if there's something not correct here -- but at least print it to the user so that we can correct that
     traceback.print_exc()
 
+norm_file_to_client = _AbsFile
+norm_file_to_server = _NormFile
 
-if PATHS_FROM_ECLIPSE_TO_PYTHON:
+def setup_client_server_paths(paths):
+    '''paths is the same format as PATHS_FROM_ECLIPSE_TO_PYTHON'''
+    
+    global NORM_FILENAME_TO_SERVER_CONTAINER
+    global NORM_FILENAME_TO_CLIENT_CONTAINER
+    global PATHS_FROM_ECLIPSE_TO_PYTHON
+    global norm_file_to_client
+    global norm_file_to_server
+    
+    NORM_FILENAME_TO_SERVER_CONTAINER = {}
+    NORM_FILENAME_TO_CLIENT_CONTAINER = {}
+    PATHS_FROM_ECLIPSE_TO_PYTHON = paths[:]
+    
+    if not PATHS_FROM_ECLIPSE_TO_PYTHON:
+        #no translation step needed (just inline the calls)
+        norm_file_to_client = _AbsFile
+        norm_file_to_server = _NormFile
+        return
+            
     #Work on the client and server slashes.
     eclipse_sep = None
     python_sep = None
@@ -258,7 +278,7 @@ if PATHS_FROM_ECLIPSE_TO_PYTHON:
 
 
     #only setup translation functions if absolutely needed!
-    def norm_file_to_server(filename):
+    def _norm_file_to_server(filename):
         #Eclipse will send the passed filename to be translated to the python process
         #So, this would be 'NormFileFromEclipseToPython'
         try:
@@ -287,8 +307,7 @@ if PATHS_FROM_ECLIPSE_TO_PYTHON:
             NORM_FILENAME_TO_SERVER_CONTAINER[filename] = translated
             return translated
 
-
-    def norm_file_to_client(filename):
+    def _norm_file_to_client(filename):
         #The result of this method will be passed to eclipse
         #So, this would be 'NormFileFromPythonToEclipse'
         try:
@@ -316,12 +335,11 @@ if PATHS_FROM_ECLIPSE_TO_PYTHON:
             #only at the beginning of this method.
             NORM_FILENAME_TO_CLIENT_CONTAINER[filename] = translated
             return translated
+    
+    norm_file_to_server = _norm_file_to_server        
+    norm_file_to_client = _norm_file_to_client
 
-else:
-    #no translation step needed (just inline the calls)
-    norm_file_to_client = _AbsFile
-    norm_file_to_server = _NormFile
-
+setup_client_server_paths(PATHS_FROM_ECLIPSE_TO_PYTHON)
 
 # For given file f returns tuple of its absolute path, real path and base name
 def get_abs_path_real_path_and_base_from_file(f):


### PR DESCRIPTION
In theory, fixes #38

In practice, I can't actually get the translation to work properly for breakpoints (on the remote side it keeps saying "trying to add breakpoint to file that does not exist"). However, when I hit the pause button it does seem to resolve the paths to my files correctly.

I'm using pydev 4.4.0, not sure if there's a known bug that would cause it to not set breakpoints correctly.