### PR TITLE
Add pydev_tracing to py_modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ args = dict(
         'pydevconsole',
         'pydevd_file_utils',
         'pydevd',
+        'pydevd_tracing',
         # 'runfiles', -- Not needed for debugger
         # 'setup_cython', -- Should not be included as a module
         # 'setup', -- Should not be included as a module


### PR DESCRIPTION
It looks like pydevd_tracing was moved from the _pydevd_bundle package to its own top-level module, but was omitted from the list of py_modules.
Without this fix, I encounter "ImportError: No module named pydevd_tracing" after installing with setup.py
