### PR TITLE
Set SetupHolder.setup upon first settrace connection

### DIFF
--- a/pydevd.py
+++ b/pydevd.py
@@ -1196,8 +1196,16 @@ def _locked_settrace(
     global bufferStdOutToServer
     global bufferStdErrToServer
 
-    if not connected :
+    if not connected:
         pydevd_vm_type.setup_type()
+
+        setup = {'client': host,  # dispatch expects client to be set to the host address when server is False
+                 'server': False,
+                 'port': int(port)}
+        if SetupHolder.setup is None:
+            SetupHolder.setup = setup
+        else:
+            SetupHolder.setup.update(setup)
 
         debugger = PyDB()
         debugger.connect(host, port)  # Note: connect can raise error.


### PR DESCRIPTION
Puts minimal setup information into SetupHolder.setup when the pydevd client is started via a settrace call. Otherwise, setup is None inside of dispatch(), and neither setup['client']  nor setup['host'] are available.
Multiprocess debugging still hangs for me, but at least it doesn't emit an error each time dispatch is called.
