### PR TITLE
Fix running `add_code_to_python_process.py` as a command on linux

### DIFF
--- a/pydevd_attach_to_process/add_code_to_python_process.py
+++ b/pydevd_attach_to_process/add_code_to_python_process.py
@@ -414,7 +414,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
     print('Attaching with arch: %s'% (arch,))
 
     target_dll = os.path.join(filedir, 'attach_linux_%s.so' % suffix)
-    target_dll = os.path.normpath(target_dll)
+    target_dll = os.path.abspath(os.path.normpath(target_dll))
     if not os.path.exists(target_dll):
         raise RuntimeError('Could not find dll file to inject: %s' % target_dll)
 


### PR DESCRIPTION
Running `python add_code_to_python_process.py <pid> 'print(42)'` on linux fails
when running from the same directory because it passes the relative path
(just the filename "attach_linux_amd64.so") to the `dlopen` call in gdb which fails.
Hence we always use the abspath to the loaded file.