### PR TITLE
Fix qt_loader to support PEP 302 correctly

### DIFF
--- a/pydev_ipython/qt_loaders.py
+++ b/pydev_ipython/qt_loaders.py
@@ -33,17 +33,17 @@ class ImportDenier(object):
         sys.modules.pop(module_name, None)
         self.__forbidden = module_name
 
-    def find_module(self, mod_name, pth):
-        if pth:
+    def find_module(self, fullname, path=None):
+        if path:
             return
-        if mod_name == self.__forbidden:
+        if fullname == self.__forbidden:
             return self
 
-    def load_module(self, mod_name):
+    def load_module(self, fullname):
         raise ImportError("""
     Importing %s disabled by IPython, which has
     already imported an Incompatible QT Binding: %s
-    """ % (mod_name, loaded_api()))
+    """ % (fullname, loaded_api()))
 
 ID = ImportDenier()
 sys.meta_path.append(ID)


### PR DESCRIPTION
This is https://github.com/ipython/ipython/pull/5933 cherry-picked to apply on PyDev.

pkgutil provides an API that makes the path optional. ipython's original implementation required a path, which broke packages that depended on calling `pkgutil.get_data`. `pkgutil.get_data` (part of the python stdlib) [calls find_module with one argument](https://github.com/python/cpython/blob/2.7/Lib/pkgutil.py#L475).