### PR TITLE
More robust creation of the coverage.xml

### DIFF
--- a/pydev_coverage.py
+++ b/pydev_coverage.py
@@ -2,6 +2,25 @@
 Entry point module to run code-coverage.
 '''
 
+
+def is_valid_py_file(path):
+    '''
+    Checks whether the file can be read by the coverage module. This is especially
+    needed for .pyx files and .py files with syntax errors.
+    '''
+    import os
+
+    is_valid = False
+    if os.path.isfile(path) and not os.path.splitext(path)[1] == '.pyx':
+        try:
+            with open(path, 'rb') as f:
+                compile(f.read(), path, 'exec')
+                is_valid = True
+        except:
+            pass
+    return is_valid
+
+
 def execute():
     import os
     import sys
@@ -17,20 +36,29 @@ def execute():
             #given in the java side, let's just gather that info here).
             sys.argv.remove('--pydev-analyze')
             try:
-                s = raw_input()
+                s = raw_input()  # @UndefinedVariable
             except:
                 s = input()
             s = s.replace('\r', '')
             s = s.replace('\n', '')
-            files = s.split('|')
-            files = [v for v in files if len(v) > 0]
 
-            #Note that in this case we'll already be in the working dir with the coverage files, so, the
-            #coverage file location is not passed.
+            files = []
+            invalid_files = []
+            for v in s.split('|'):
+                if is_valid_py_file(v):
+                    files.append(v)
+                else:
+                    invalid_files.append(v)
+            if invalid_files:
+                sys.stderr.write('Invalid files not passed to coverage: %s'
+                                 % ', '.join(invalid_files))
+
+            # Note that in this case we'll already be in the working dir with the coverage files, 
+            # so, the coverage file location is not passed.
 
         else:
-            #For all commands, the coverage file is configured in pydev, and passed as the first argument
-            #in the command line, so, let's make sure this gets to the coverage module.
+            # For all commands, the coverage file is configured in pydev, and passed as the first 
+            # argument in the command line, so, let's make sure this gets to the coverage module.
             os.environ['COVERAGE_FILE'] = sys.argv[1]
             del sys.argv[1]
 
@@ -38,18 +66,24 @@ def execute():
         import coverage #@UnresolvedImport
     except:
         sys.stderr.write('Error: coverage module could not be imported\n')
-        sys.stderr.write('Please make sure that the coverage module (http://nedbatchelder.com/code/coverage/)\n')
+        sys.stderr.write('Please make sure that the coverage module '
+                         '(http://nedbatchelder.com/code/coverage/)\n')
         sys.stderr.write('is properly installed in your interpreter: %s\n' % (sys.executable,))
 
         import traceback;traceback.print_exc()
         return
-    
-    version = tuple(map(int, coverage.__version__.split('.')[:2]))
-    if version < (4, 3):
-        sys.stderr.write('Error: minimum supported coverage version is 4.3.\nFound: %s\nLocation: %s' % ('.'.join(str(x) for x in version), coverage.__file__))
-        sys.exit(1)
 
-    #print(coverage.__version__) TODO: Check if the version is a version we support (should be at least 3.4) -- note that maybe the attr is not there.
+    if hasattr(coverage, '__version__'):
+        version = tuple(map(int, coverage.__version__.split('.')[:2]))
+        if version < (4, 3):
+            sys.stderr.write('Error: minimum supported coverage version is 4.3.'
+                             '\nFound: %s\nLocation: %s' 
+                             % ('.'.join(str(x) for x in version), coverage.__file__))
+            sys.exit(1)
+    else:
+        sys.stderr.write('Warning: Could not determine version of python module coverage.'
+                         '\nEnsure coverage version is >= 4.3')
+
     from coverage.cmdline import main #@UnresolvedImport
 
     if files is not None:

--- a/tests_python/resources/_pydev_coverage_cyrillic_encoding_py2.py
+++ b/tests_python/resources/_pydev_coverage_cyrillic_encoding_py2.py
@@ -1,0 +1,8 @@
+# -*- coding: iso-8859-5 -*-
+
+# Æ²³´µ¶
+class Dummy(object):
+    def Print(self):
+        print ('Æ²³´µ¶')
+
+Dummy().Print()

--- a/tests_python/resources/_pydev_coverage_cyrillic_encoding_py3.py
+++ b/tests_python/resources/_pydev_coverage_cyrillic_encoding_py3.py
@@ -1,0 +1,8 @@
+# -*- coding: iso-8859-5 -*-
+
+# ∆≤≥¥µ∂
+class Dummy∆≤≥¥µ∂(object):
+    def Print(self):
+        print ('∆≤≥¥µ∂')
+
+Dummy∆≤≥¥µ∂().Print()

--- a/tests_python/resources/_pydev_coverage_syntax_error.py
+++ b/tests_python/resources/_pydev_coverage_syntax_error.py
@@ -1,0 +1,8 @@
+# -*- coding: iso-8859-5 -*-
+
+# Æ²³´µ¶
+class Dummy(object):
+    def Print(self)
+        print ('Æ²³´µ¶')
+
+Dummy().Print()

--- a/tests_python/test_pydevcoverage.py
+++ b/tests_python/test_pydevcoverage.py
@@ -1,0 +1,64 @@
+import os
+import re
+import sys
+import subprocess
+import unittest
+
+
+#=======================================================================================================================
+# Test
+#=======================================================================================================================
+class Test(unittest.TestCase):
+    """
+    Unittest for pydev_coverage.py.
+    TODO:
+      - 'combine' in arguments
+      - no 'combine' and no 'pydev-analyze' in arguments
+    """
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        project_path = os.path.dirname(os.path.dirname(__file__))
+        self._resources_path = os.path.join(project_path, "tests_python", "resources")
+        self._coverage_file = os.path.join(project_path, "pydev_coverage.py")
+
+    def _do_analyze(self, files):
+        invalid_files = []
+
+        p = subprocess.Popen(["python", self._coverage_file, "--pydev-analyze"],
+                             stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        __, stderrdata = p.communicate("|".join(files).encode())
+
+        if stderrdata:
+            match = re.search("Invalid files not passed to coverage: (.*?)$",
+                              stderrdata.decode(), re.M)  # @UndefinedVariable
+            if match:
+                invalid_files = [f.strip() for f in match.group(1).split(",")]
+        return invalid_files
+
+    def test_pydev_analyze_ok(self):
+        ref_valid_files = [__file__,
+            os.path.join(self._resources_path, "_debugger_case18.py")]
+        ref_invalid_files = []
+
+        invalid_files = self._do_analyze(ref_valid_files)
+
+        self.assertEqual(ref_invalid_files, invalid_files)
+
+    def test_pydev_analyse_non_standard_encoding(self):
+        ref_valid_files = [os.path.join(self._resources_path,
+                                        "_pydev_coverage_cyrillic_encoding_py{}.py"
+                                            .format(sys.version_info[0]))]
+        ref_invalid_files = []
+
+        invalid_files = self._do_analyze(ref_valid_files + ref_invalid_files)
+
+        self.assertEqual(ref_invalid_files, invalid_files)
+
+    def test_pydev_analyse_invalid_files(self):
+        ref_valid_files = []
+        ref_invalid_files = [os.path.join(self._resources_path, "_pydev_coverage_syntax_error.py")]
+
+        invalid_files = self._do_analyze(ref_valid_files + ref_invalid_files)
+
+        self.assertEqual(ref_invalid_files, invalid_files)

--- a/tests_python/test_pydevcoverage.py
+++ b/tests_python/test_pydevcoverage.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 import subprocess
+import tempfile
 import unittest
 
 
@@ -56,9 +57,12 @@ class Test(unittest.TestCase):
         self.assertEqual(ref_invalid_files, invalid_files)
 
     def test_pydev_analyse_invalid_files(self):
-        ref_valid_files = []
-        ref_invalid_files = [os.path.join(self._resources_path, "_pydev_coverage_syntax_error.py")]
+        with tempfile.NamedTemporaryFile(suffix=".pyx") as pyx_file:
+            ref_valid_files = []
+            ref_invalid_files = [os.path.join(self._resources_path,
+                                              "_pydev_coverage_syntax_error.py"),
+                                 pyx_file.name]
 
-        invalid_files = self._do_analyze(ref_valid_files + ref_invalid_files)
+            invalid_files = self._do_analyze(ref_valid_files + ref_invalid_files)
 
-        self.assertEqual(ref_invalid_files, invalid_files)
+            self.assertEqual(ref_invalid_files, invalid_files)


### PR DESCRIPTION
Now, the pull request into the correct repository. ;-)

The changes of this pull request fix the issue that a python file with syntax error or a .pyx file prevent the generation of the coverage.xml and the display of coverage results when working with the coverage view of PyDev.

In addition, there is more robustness in case that the version of the coverage module could not be determined. 