### PR TITLE
Add missing type casting

### DIFF
--- a/pydevd_attach_to_process/_test_attach_to_process_linux.py
+++ b/pydevd_attach_to_process/_test_attach_to_process_linux.py
@@ -58,8 +58,8 @@ if __name__ == '__main__':
         
     cmd.extend([
         "--eval-command='call dlopen(\"/home/fabioz/Desktop/dev/PyDev.Debugger/pydevd_attach_to_process/linux/attach_linux.so\", 2)'",
-        "--eval-command='call DoAttach(1, \"print(\\\"check11111check\\\")\", 0)'",
-        #"--eval-command='call SetSysTraceFunc(1, 0)'", -- never call this way, always use "--command='...gdb_threads_settrace.py'",
+        "--eval-command='call (int)DoAttach(1, \"print(\\\"check11111check\\\")\", 0)'",
+        #"--eval-command='call (int)SetSysTraceFunc(1, 0)'", -- never call this way, always use "--command='...gdb_threads_settrace.py'",
         #So that threads are all stopped!
         "--command='/home/fabioz/Desktop/dev/PyDev.Debugger/pydevd_attach_to_process/linux/gdb_threads_settrace.py'",
     ])

--- a/pydevd_attach_to_process/add_code_to_python_process.py
+++ b/pydevd_attach_to_process/add_code_to_python_process.py
@@ -441,7 +441,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
 
     cmd.extend([
         "--eval-command='call dlopen(\"%s\", 2)'" % target_dll,
-        "--eval-command='call DoAttach(%s, \"%s\", %s)'" % (
+        "--eval-command='call (int)DoAttach(%s, \"%s\", %s)'" % (
             is_debug, python_code, show_debug_info)
     ])
 

--- a/pydevd_attach_to_process/linux/gdb_threads_settrace.py
+++ b/pydevd_attach_to_process/linux/gdb_threads_settrace.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
             t.switch()
             if t.is_stopped():
                 #print('Will settrace in: %s' % (t,))
-                gdb.execute("call SetSysTraceFunc(%s, %s)" % (
+                gdb.execute("call (int)SetSysTraceFunc(%s, %s)" % (
                     show_debug_info, is_debug))
     except:
         import traceback;traceback.print_exc()


### PR DESCRIPTION
`python3 PyDev.Debugger/pydevd_attach_to_process/attach_pydevd.py --pid $SOME_PID` results in an error (OS: openSUSE Tumbleweed):
```
stderr: b'\'DoAttach(bool, char const*, bool)\' has unknown return type; cast the call to its declared return type\nTraceback (most recent call last):\n  File "/home/adwin/libraries/PyDev.Debugger/pydevd_attach_to_process/linux/gdb_threads_settrace.py", line 14, in <module>\n    show_debug_info, is_debug))\ngdb.error: \'SetSysTraceFunc(bool, bool)\' has unknown return type; cast the call to its declared return type\n'
```
Same error occurs when using bundled version of PyDev.Debugger in PyCharm 2018.2.2 (Run -> Attach to Process..):
![screenshot_20180829_001121](https://user-images.githubusercontent.com/8993001/44753918-1ab25c80-ab20-11e8-8c2d-d2c8f3e7bb8c.png)


After adding type casting attaching to a running process works like a charm.