### PR TITLE
Fix dlopen return type for gdb 8.3.1

### DIFF
--- a/pydevd_attach_to_process/add_code_to_python_process.py
+++ b/pydevd_attach_to_process/add_code_to_python_process.py
@@ -470,7 +470,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
     cmd.extend(["--eval-command='set architecture %s'" % arch])
 
     cmd.extend([
-        "--eval-command='call dlopen(\"%s\", 2)'" % target_dll,
+        "--eval-command='call (void*)dlopen(\"%s\", 2)'" % target_dll,
         "--eval-command='call (int)DoAttach(%s, \"%s\", %s)'" % (
             is_debug, python_code, show_debug_info)
     ])


### PR DESCRIPTION
I must prepend dlopen() with return type (void*) on last ArchLinux with gdb 8.3.1, otherwise the dlopen is not called at all and then DoAttach is not found.