### PR TITLE
Fix typo in README.rst?

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ any other variant which properly supports the Python structure for debuggers -- 
 
 Recent versions contain speedup modules using Cython, which are generated with a few changes in the regular files
 to `cythonize` the files. To update and compile the cython sources (and generate some other auto-generated files),
-`build_tools/build.py` should be run -- note that the resulting .pyx and .c files should be commited.
+`build_tools/build.py` should be run -- note that the resulting .pyx and .c files should not be committed.
 
 To generate a distribution with the precompiled binaries for the IDE, `build_binaries_windows.py` should be run (
 note that the environments must be pre-created as specified in that file).


### PR DESCRIPTION
I'm wondering whether this is a small typo in the README (it struck me as being unusual to say the compiled files should be committed).