### PR TITLE
fix for pytest >=5.4

### DIFF
--- a/_pydev_runfiles/pydev_runfiles_pytest2.py
+++ b/_pydev_runfiles/pydev_runfiles_pytest2.py
@@ -158,7 +158,7 @@ try:
     so try load pytest version first or fallback to default one
     """
     from _pytest._io import TerminalWriter
-except (ImportError, ModuleNotFoundError):
+except ImportError:
     from py.io import TerminalWriter
 
 

--- a/_pydev_runfiles/pydev_runfiles_pytest2.py
+++ b/_pydev_runfiles/pydev_runfiles_pytest2.py
@@ -151,7 +151,15 @@ def pytest_collection_modifyitems(session, config, items):
     pydev_runfiles_xml_rpc.notifyTestsCollected(len(items))
 
 
-from py.io import TerminalWriter
+try:
+    """
+    pytest > 5.4 uses own version of TerminalWriter based on py.io.TerminalWriter
+    and assumes there is a specific method TerminalWriter._write_source
+    so try load pytest version first or fallback to default one
+    """
+    from _pytest._io import TerminalWriter
+except (ImportError, ModuleNotFoundError):
+    from py.io import TerminalWriter
 
 
 def _get_error_contents_from_report(report):


### PR DESCRIPTION
pytest > 5.4 uses own version of TerminalWriter based on py.io.TerminalWriter
and assumes there is a specific method TerminalWriter._write_source
so try load pytest version first or fallback to default one