### PR TITLE
Improve the quoting logic in run_python_code_{linux,mac}

### DIFF
--- a/pydevd_attach_to_process/add_code_to_python_process.py
+++ b/pydevd_attach_to_process/add_code_to_python_process.py
@@ -371,7 +371,7 @@ def run_python_code_mac(pid, python_code, connect_debugger_tracing=False, show_d
     print('Attaching with arch: %s' % (arch,))
 
     target_dll = os.path.join(filedir, 'attach_%s' % suffix)
-    target_dll = os.path.normpath(target_dll)
+    target_dll = os.path.abspath(target_dll)
     if not os.path.exists(target_dll):
         raise RuntimeError('Could not find dll file to inject: %s' % target_dll)
 

--- a/pydevd_attach_to_process/add_code_to_python_process.py
+++ b/pydevd_attach_to_process/add_code_to_python_process.py
@@ -266,6 +266,15 @@ def _win_write_to_shared_named_memory(python_code, pid):
     finally:
         CloseHandle(filemap)
 
+def escape_for_gdb_and_lldb(s):
+    """Returns a version of given string suitable for use as gdb
+       and lldb function argument"""
+    if not s:
+        return '""'
+
+    # wrap string in double qoutes, and escape any inner double
+    # quotes
+    return '"' + s.replace('"', '\"') + '"'
 
 def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show_debug_info=0):
     assert '\'' not in python_code, 'Having a single quote messes with our command.'

--- a/pydevd_attach_to_process/add_code_to_python_process.py
+++ b/pydevd_attach_to_process/add_code_to_python_process.py
@@ -355,7 +355,6 @@ def find_helper_script(filedir, script_name):
 
 
 def run_python_code_mac(pid, python_code, connect_debugger_tracing=False, show_debug_info=0):
-    assert '\'' not in python_code, 'Having a single quote messes with our command.'
     filedir = os.path.dirname(__file__)
 
     # Valid arguments for arch are i386, i386:x86-64, i386:x64-32, i8086,
@@ -394,15 +393,15 @@ def run_python_code_mac(pid, python_code, connect_debugger_tracing=False, show_d
     ]
 
     cmd.extend([
-        "-o 'process attach --pid %d'" % pid,
-        "-o 'command script import \"%s\"'" % (lldb_prepare_file,),
-        "-o 'load_lib_and_attach \"%s\" %s \"%s\" %s'" % (target_dll,
-            is_debug, python_code, show_debug_info),
+        "-o", 'process attach --pid %d' % pid,
+        "-o", 'command script import "%s"' % (lldb_prepare_file,),
+        "-o", 'load_lib_and_attach "%s" %s %s %s' % (target_dll,
+            is_debug, escape_for_gdb_and_lldb(python_code), show_debug_info),
     ])
 
     cmd.extend([
-        "-o 'process detach'",
-        "-o 'script import os; os._exit(1)'",
+        "-o", 'process detach',
+        "-o", 'script import os; os._exit(1)',
     ])
 
     # print ' '.join(cmd)
@@ -414,8 +413,7 @@ def run_python_code_mac(pid, python_code, connect_debugger_tracing=False, show_d
     env.pop('PYTHONPATH', None)
     print('Running: %s' % (' '.join(cmd)))
     p = subprocess.Popen(
-        ' '.join(cmd),
-        shell=True,
+        cmd,
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
Let's try this again :)

All the tests pass now, except the Python 3.9 one, which seems to never pass, so I'm assuming it's unrelated to this patch.