### PR TITLE
Fix output message typo

### DIFF
--- a/_pydevd_bundle/pydevd_net_command_factory_json.py
+++ b/_pydevd_bundle/pydevd_net_command_factory_json.py
@@ -405,7 +405,7 @@ class NetCommandFactoryJson(NetCommandFactory):
 
     @overrides(NetCommandFactory.make_evaluation_timeout_msg)
     def make_evaluation_timeout_msg(self, py_db, expression, curr_thread):
-        msg = '''Evaluating: %s did not finish after %.2fs seconds.
+        msg = '''Evaluating: %s did not finish after %.2f seconds.
 This may mean a number of things:
 - This evaluation is really slow and this is expected.
     In this case it's possible to silence this error by raising the timeout, setting the

--- a/_pydevd_bundle/pydevd_net_command_factory_xml.py
+++ b/_pydevd_bundle/pydevd_net_command_factory_xml.py
@@ -460,7 +460,7 @@ class NetCommandFactory(object):
         return NULL_NET_COMMAND  # Not a part of the xml protocol
 
     def make_evaluation_timeout_msg(self, py_db, expression, thread):
-        msg = '''pydevd: Evaluating: %s did not finish after %.2fs seconds.
+        msg = '''pydevd: Evaluating: %s did not finish after %.2f seconds.
 This may mean a number of things:
 - This evaluation is really slow and this is expected.
     In this case it's possible to silence this error by raising the timeout, setting the


### PR DESCRIPTION
"function() did not finish after 3.00s seconds." had the unit (seconds) stated twice (both as "s" and as "seconds").
