### PR TITLE
Update release_mem.h to handle NULL on `co_extra`

### DIFF
--- a/_pydevd_frame_eval/release_mem.h
+++ b/_pydevd_frame_eval/release_mem.h
@@ -1,5 +1,5 @@
 #include "Python.h"
 
 void release_co_extra(void *obj) {
-    Py_DECREF(obj);
+    Py_XDECREF(obj);
 }


### PR DESCRIPTION
Uses the null-friendly on `release_co_extra` incase the `co_extra` field is null.

I'm hitting a crash on this situation. 

```
Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Segmentation fault: 11
Termination Reason:    Namespace SIGNAL, Code 0xb
Terminating Process:   exc handler [12641]

VM Regions Near 0:
--> 
    __TEXT                 0000000101726000-0000000101727000 [    4K] r-x/rwx SM=COW  /Library/Frameworks/Python.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   pydevd_frame_evaluator_common.cpython-39-darwin.so	0x0000000102158d94 release_co_extra + 4
1   org.python.python             	0x0000000101771414 code_dealloc + 132
2   org.python.python             	0x0000000101786512 frame_dealloc + 162
3   org.python.python             	0x000000010176da62 function_code_fastcall + 226
4   org.python.python             	0x000000010184382c call_function + 732
```