### PR TITLE
set socket as inheritable

### DIFF
--- a/_pydevd_bundle/pydevd_comm.py
+++ b/_pydevd_bundle/pydevd_comm.py
@@ -437,6 +437,11 @@ def start_client(host, port):
 
     s = socket(AF_INET, SOCK_STREAM)
 
+    # Since python 3.4, sockets are by default non inheritable,
+    # inheritance must be set to true to allow applications to work with child processes
+    if hasattr(s, 'set_inheritable'):
+        s.set_inheritable(True)
+
     #  Set TCP keepalive on an open socket.
     #  It activates after 1 second (TCP_KEEPIDLE,) of idleness,
     #  then sends a keepalive ping once every 3 seconds (TCP_KEEPINTVL),


### PR DESCRIPTION
Setting the client socket as inheritable would fix issues with the debugger when the application creates a child process with `os.execv`. This behavior used to work prior to python 3.4, since python 3.4, sockets are by default not inheritable. 
Link to the relevant python doc: https://docs.python.org/3/library/os.html#fd-inheritance

More specifically, this fix will allow us to debug bazel programs with the bazel intellij plugin. Thread here: https://github.com/bazelbuild/intellij/issues/402
