### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,20 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
+      - run: bandit -r . || true
+      - run: black --check . || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --check-only --profile black . || true
+      - run: pip install -r requirements.txt || true
+      - run: mypy --ignore-missing-imports . || true
+      - run: pytest . || true
+      - run: pytest --doctest-modules . || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -10,7 +10,7 @@ jobs:
       - run: bandit -r . || true
       - run: black --check . || true
       - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
-      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: flake8 . --count --exclude=./.*,./tests_python,./third_party --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt || true
       - run: mypy --ignore-missing-imports . || true

--- a/_pydev_bundle/_pydev_completer.py
+++ b/_pydev_bundle/_pydev_completer.py
@@ -18,6 +18,11 @@ except ImportError:
     IS_JYTHON = False
     from _pydev_bundle import _pydev_imports_tipper
 
+try:
+    unicode
+except NameError: 
+    unicode = str
+
 dir2 = _pydev_imports_tipper.generate_imports_tip_for_module
 
 
@@ -84,6 +89,7 @@ class Completer:
         returns None.  The completion should begin with 'text'.
 
         """
+        global __main__
         if self.use_main_ns:
             # In pydev this option should never be used
             raise RuntimeError('Namespace must be provided!')

--- a/_pydev_bundle/_pydev_imports_tipper.py
+++ b/_pydev_bundle/_pydev_imports_tipper.py
@@ -24,7 +24,7 @@ else:
 
 try:
     xrange
-except:
+except NameError:
     xrange = range
 
 # completion types.

--- a/_pydev_bundle/_pydev_jy_imports_tipper.py
+++ b/_pydev_bundle/_pydev_jy_imports_tipper.py
@@ -1,6 +1,6 @@
 try:
     import StringIO
-except:
+except ImportError:
     import io as StringIO
 
 import traceback
@@ -17,8 +17,13 @@ from org.python import core #@UnresolvedImport
 from org.python.core import PyClass #@UnresolvedImport
 
 try:
+    unicode
+except NameError:
+    unicode = str
+
+try:
     xrange
-except:
+except NameError:
     xrange = range
 
 

--- a/_pydev_bundle/pydev_monkey.py
+++ b/_pydev_bundle/pydev_monkey.py
@@ -12,7 +12,7 @@ from _pydevd_bundle.pydevd_defaults import PydevdCustomization
 
 try:
     xrange
-except:
+except NameError:
     xrange = range
 
 #===============================================================================

--- a/_pydev_bundle/pydev_umd.py
+++ b/_pydev_bundle/pydev_umd.py
@@ -33,6 +33,12 @@ OTHER DEALINGS IN THE SOFTWARE.
 import sys
 import os
 
+try:
+    basestring
+except NameError:
+    basestring = str,
+
+
 # The following classes and functions are mainly intended to be used from
 # an interactive Python session
 class UserModuleDeleter:
@@ -164,7 +170,8 @@ def runfile(filename, args=None, wdir=None, namespace=None):
         except (UnicodeError, TypeError):
             pass
         os.chdir(wdir)
-    execfile(filename, namespace)
+    with open(filename) as in_file:
+        exec(in_file.read(), namespace)
     sys.argv = ['']
     if old_file is None:
         del namespace['__file__']

--- a/_pydev_imps/_pydev_SimpleXMLRPCServer.py
+++ b/_pydev_imps/_pydev_SimpleXMLRPCServer.py
@@ -260,7 +260,7 @@ class SimpleXMLRPCDispatcher:
             response = (response,)
             response = xmlrpclib.dumps(response, methodresponse=1,
                                        allow_none=self.allow_none, encoding=self.encoding)
-        except Fault, fault:
+        except Fault as fault:
             response = xmlrpclib.dumps(fault, allow_none=self.allow_none,
                                        encoding=self.encoding)
         except:
@@ -363,7 +363,7 @@ class SimpleXMLRPCDispatcher:
                 # XXX A marshalling error in any response will fail the entire
                 # multicall. If someone cares they should fix this.
                 results.append([self._dispatch(method_name, params)])
-            except Fault, fault:
+            except Fault as fault:
                 results.append(
                     {'faultCode' : fault.faultCode,
                      'faultString' : fault.faultString}

--- a/_pydev_imps/_pydev_SocketServer.py
+++ b/_pydev_imps/_pydev_SocketServer.py
@@ -118,6 +118,7 @@ BaseServer:
   entry is processed by a RequestHandlerClass.
 
 """
+from __future__ import print_function
 
 # Author of the BaseServer patch: Luke Kenneth Casson Leighton
 
@@ -336,12 +337,12 @@ class BaseServer:
         The default is to print a traceback and continue.
 
         """
-        print '-'*40
-        print 'Exception happened during processing of request from',
-        print client_address
+        print('-'*40)
+        print('Exception happened during processing of request from', end=' ')
+        print(client_address)
         import traceback
         traceback.print_exc() # XXX But this goes to stderr!
-        print '-'*40
+        print('-'*40)
 
 
 class TCPServer(BaseServer):
@@ -528,7 +529,7 @@ class ForkingMixIn:
             if not pid: continue
             try:
                 self.active_children.remove(pid)
-            except ValueError, e:
+            except ValueError as e:
                 raise ValueError('%s. x=%d and list=%r' % (e.message, pid,
                                                            self.active_children))
 

--- a/_pydev_imps/_pydev_inspect.py
+++ b/_pydev_imps/_pydev_inspect.py
@@ -290,12 +290,12 @@ def getfile(object):
     if ismodule(object):
         if hasattr(object, '__file__'):
             return object.__file__
-        raise TypeError, 'arg is a built-in module'
+        raise TypeError('arg is a built-in module')
     if isclass(object):
         object = sys.modules.get(object.__module__)
         if hasattr(object, '__file__'):
             return object.__file__
-        raise TypeError, 'arg is a built-in class'
+        raise TypeError('arg is a built-in class')
     if ismethod(object):
         object = object.im_func
     if isfunction(object):
@@ -306,14 +306,14 @@ def getfile(object):
         object = object.f_code
     if iscode(object):
         return object.co_filename
-    raise TypeError, 'arg is not a module, class, method, ' \
-                     'function, traceback, frame, or code object'
+    raise TypeError('arg is not a module, class, method, '
+                    'function, traceback, frame, or code object')
 
 def getmoduleinfo(path):
     """Get the module name, suffix, mode, and module type for a given file."""
     filename = os.path.basename(path)
     suffixes = map(lambda (suffix, mode, mtype):
-                   (-len(suffix), suffix, mode, mtype), imp.get_suffixes())
+-                  (-len(suffix), suffix, mode, mtype), imp.get_suffixes())
     suffixes.sort() # try longest suffixes first, in case they overlap
     for neglen, suffix, mode, mtype in suffixes:
         if filename[neglen:] == suffix:
@@ -384,7 +384,7 @@ def findsource(object):
     try:
         file = open(getsourcefile(object))
     except (TypeError, IOError):
-        raise IOError, 'could not get source code'
+        raise IOError('could not get source code')
     lines = file.readlines()
     file.close()
 
@@ -396,7 +396,7 @@ def findsource(object):
         pat = re.compile(r'^\s*class\s*' + name + r'\b')
         for i in range(len(lines)):
             if pat.match(lines[i]): return lines, i
-        else: raise IOError, 'could not find class definition'
+        else: raise IOError('could not find class definition')
 
     if ismethod(object):
         object = object.im_func
@@ -408,14 +408,14 @@ def findsource(object):
         object = object.f_code
     if iscode(object):
         if not hasattr(object, 'co_firstlineno'):
-            raise IOError, 'could not find function definition'
+            raise IOError('could not find function definition')
         lnum = object.co_firstlineno - 1
         pat = re.compile(r'^(\s*def\s)|(.*\slambda(:|\s))')
         while lnum > 0:
             if pat.match(lines[lnum]): break
             lnum = lnum - 1
         return lines, lnum
-    raise IOError, 'could not find code object'
+    raise IOError('could not find code object')
 
 def getcomments(object):
     """Get lines of comments immediately preceding an object's source code."""
@@ -488,15 +488,15 @@ class BlockFinder:
             self.indent = self.indent + 1
         elif type == tokenize.DEDENT:
             self.indent = self.indent - 1
-            if self.indent == 0: raise EndOfBlock, self.last
+            if self.indent == 0:raise_(EndOfBlock, self.last)
         elif type == tokenize.NAME and scol == 0:
-            raise EndOfBlock, self.last
+            raise_(EndOfBlock, self.last)
 
 def getblock(lines):
     """Extract the block of code at the top of the given list of lines."""
     try:
         tokenize.tokenize(ListReader(lines).readline, BlockFinder().tokeneater)
-    except EndOfBlock, eob:
+    except EndOfBlock as eob:
         return lines[:eob.args[0]]
     # Fooling the indent/dedent logic implies a one-line definition
     return lines[:1]
@@ -569,7 +569,7 @@ def getargs(co):
     Three things are returned: (args, varargs, varkw), where 'args' is
     a list of argument names (possibly containing nested lists), and
     'varargs' and 'varkw' are the names of the * and ** arguments or None."""
-    if not iscode(co): raise TypeError, 'arg is not a code object'
+    if not iscode(co): raise TypeError('arg is not a code object')
 
     nargs = co.co_argcount
     names = co.co_varnames
@@ -623,7 +623,7 @@ def getargspec(func):
     'defaults' is an n-tuple of the default values of the last n arguments."""
     if ismethod(func):
         func = func.im_func
-    if not isfunction(func): raise TypeError, 'arg is not a Python function'
+    if not isfunction(func): raise TypeError('arg is not a Python function')
     args, varargs, varkw = getargs(func.func_code)
     return args, varargs, varkw, func.func_defaults
 

--- a/_pydev_imps/_pydev_pkgutil_old.py
+++ b/_pydev_imps/_pydev_pkgutil_old.py
@@ -15,6 +15,11 @@ __all__ = [
     'ImpImporter', 'ImpLoader', 'read_code', 'extend_path',
 ]
 
+try:
+    basestring
+except NameError:
+    basestring = str,
+
 def read_code(stream):
     # This helper is needed in order for the PEP 302 emulation to
     # correctly handle compiled files
@@ -540,7 +545,7 @@ def extend_path(path, name):
         if os.path.isfile(pkgfile):
             try:
                 f = open(pkgfile)
-            except IOError, msg:
+            except IOError as msg:
                 sys.stderr.write("Can't open %s: %s\n" %
                                  (pkgfile, msg))
             else:

--- a/_pydev_imps/_pydev_xmlrpclib.py
+++ b/_pydev_imps/_pydev_xmlrpclib.py
@@ -1,5 +1,6 @@
 #Just a copy of the version in python 2.5 to be used if it's not available in jython 2.1
 import sys
+# flake8: noqa
 
 #
 # XML-RPC CLIENT LIBRARY

--- a/_pydev_runfiles/pydev_runfiles_pytest2.py
+++ b/_pydev_runfiles/pydev_runfiles_pytest2.py
@@ -10,8 +10,15 @@ import time
 
 try:
     from pathlib import Path
-except:
+except ImportError:
     Path = None
+
+try:
+    basestring
+    unicode
+except NameError:
+    basestring = str,
+    unicode = str
 
 #=========================================================================
 # Load filters with tests we should skip

--- a/_pydev_runfiles/pydev_runfiles_xml_rpc.py
+++ b/_pydev_runfiles/pydev_runfiles_xml_rpc.py
@@ -7,6 +7,11 @@ from _pydev_bundle._pydev_filesystem_encoding import getfilesystemencoding
 from _pydev_bundle.pydev_imports import xmlrpclib, _queue
 from _pydevd_bundle.pydevd_constants import Null, IS_PY3K
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 Queue = _queue.Queue
 
 #This may happen in IronPython (in Python it shouldn't happen as there are

--- a/_pydevd_bundle/pydevconsole_code_for_ironpython.py
+++ b/_pydevd_bundle/pydevconsole_code_for_ironpython.py
@@ -8,7 +8,12 @@
 import sys
 import traceback
 
-
+try:
+    raw_input
+    unicode
+except NameError:
+    raw_input = input
+    unicode = str
 
 
 
@@ -102,23 +107,23 @@ def _maybe_compile(compiler, source, filename, symbol):
 
     try:
         code = compiler(source, filename, symbol)
-    except SyntaxError, err:
+    except SyntaxError as err:
         pass
 
     try:
         code1 = compiler(source + "\n", filename, symbol)
-    except SyntaxError, err1:
+    except SyntaxError as err1:
         pass
 
     try:
         code2 = compiler(source + "\n\n", filename, symbol)
-    except SyntaxError, err2:
+    except SyntaxError as err2:
         pass
 
     if code:
         return code
     if not code1 and repr(err1) == repr(err2):
-        raise SyntaxError, err1
+        raise SyntaxError(err1)
 
 def _compile(source, filename, symbol):
     return compile(source, filename, symbol, PyCF_DONT_IMPLY_DEDENT)
@@ -302,7 +307,7 @@ class InteractiveInterpreter:
 
         """
         try:
-            exec code in self.locals
+            exec(code, self.locals)
         except SystemExit:
             raise
         except:

--- a/_pydevd_bundle/pydevd_code_to_source.py
+++ b/_pydevd_bundle/pydevd_code_to_source.py
@@ -15,7 +15,7 @@ import inspect
 
 try:
     xrange = xrange
-except:
+except NameError:
     xrange = range
 
 
@@ -520,7 +520,7 @@ def _compose_line_contents(line_contents, previous_line_tokens):
 
             try:
                 from StringIO import StringIO
-            except:
+            except ImportError:
                 from io import StringIO
             stream = StringIO()
             _print_after_info(line_contents, stream)

--- a/_pydevd_bundle/pydevd_constants.py
+++ b/_pydevd_bundle/pydevd_constants.py
@@ -17,8 +17,12 @@ JINJA2_SUSPEND = 3
 
 try:
     int_types = (int, long)
+    unicode
+    xrange
 except NameError:
     int_types = (int,)
+    unicode = str
+    xrange = range
 
 # types does not include a MethodWrapperType
 try:

--- a/_pydevd_bundle/pydevd_exec.py
+++ b/_pydevd_bundle/pydevd_exec.py
@@ -1,5 +1,5 @@
 def Exec(exp, global_vars, local_vars=None):
     if local_vars is not None:
-        exec exp in global_vars, local_vars
+        exec(exp, global_vars, local_vars)
     else:
-        exec exp in global_vars
+        exec(exp, global_vars)

--- a/_pydevd_bundle/pydevd_filtering.py
+++ b/_pydevd_bundle/pydevd_filtering.py
@@ -14,9 +14,11 @@ from _pydevd_bundle.pydevd_constants import USER_CODE_BASENAMES_STARTING_WITH, \
 from _pydevd_bundle import pydevd_constants
 
 try:
-    xrange  # noqa
+    unicode
+    xrange
 except NameError:
-    xrange = range  # noqa
+    unicode = str
+    xrange = range
 
 ExcludeFilter = namedtuple('ExcludeFilter', 'name, exclude, is_path')
 

--- a/_pydevd_bundle/pydevd_io.py
+++ b/_pydevd_bundle/pydevd_io.py
@@ -3,6 +3,11 @@ import os
 import sys
 from contextlib import contextmanager
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 
 class IORedirector:
     '''

--- a/_pydevd_bundle/pydevd_net_command.py
+++ b/_pydevd_bundle/pydevd_net_command.py
@@ -7,6 +7,11 @@ from _pydevd_bundle.pydevd_constants import HTTP_PROTOCOL, HTTP_JSON_PROTOCOL, \
 import json
 from _pydev_bundle import pydev_log
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 
 class _BaseNetCommand(object):
 

--- a/_pydevd_bundle/pydevd_process_net_command.py
+++ b/_pydevd_bundle/pydevd_process_net_command.py
@@ -19,6 +19,11 @@ from _pydevd_bundle.pydevd_net_command import NetCommand
 from _pydevd_bundle.pydevd_thread_lifecycle import pydevd_find_thread_by_id
 import pydevd_file_utils
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 
 class _PyDevCommandProcessor(object):
 

--- a/_pydevd_bundle/pydevd_safe_repr.py
+++ b/_pydevd_bundle/pydevd_safe_repr.py
@@ -8,14 +8,14 @@ from _pydevd_bundle.pydevd_constants import IS_PY2
 import locale
 from _pydev_bundle import pydev_log
 
-# Py3 compat - alias unicode to str, and xrange to range
+# Py3 compat - alias unichr to chr, unicode to str, and xrange to range
 try:
-    unicode  # noqa
+    unichr
+    unicode
+    xrange
 except NameError:
+    unichr = chr
     unicode = str
-try:
-    xrange  # noqa
-except NameError:
     xrange = range
 
 

--- a/_pydevd_bundle/pydevd_utils.py
+++ b/_pydevd_bundle/pydevd_utils.py
@@ -9,7 +9,7 @@ import ctypes
 
 try:
     from urllib import quote
-except:
+except ImportError:
     from urllib.parse import quote  # @UnresolvedImport
 
 import inspect
@@ -17,6 +17,13 @@ import sys
 from _pydevd_bundle.pydevd_constants import IS_PY3K, USE_CUSTOM_SYS_CURRENT_FRAMES, IS_PYPY, SUPPORT_GEVENT, \
     GEVENT_SUPPORT_NOT_SET_MSG, GENERATED_LEN_ATTR_NAME
 from _pydev_imps._pydev_saved_modules import threading
+
+try:
+    basestring
+    unicode
+except NameError:
+    basestring = str,
+    unicode = str
 
 
 def save_main_module(file, module_name):

--- a/_pydevd_bundle/pydevd_vars.py
+++ b/_pydevd_bundle/pydevd_vars.py
@@ -25,6 +25,11 @@ from _pydevd_bundle import pydevd_save_locals, pydevd_timeout, pydevd_constants,
 from _pydev_bundle.pydev_imports import Exec, execfile
 from _pydevd_bundle.pydevd_utils import to_string
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 SENTINEL_VALUE = []
 
 

--- a/_pydevd_bundle/pydevd_xml.py
+++ b/_pydevd_bundle/pydevd_xml.py
@@ -17,6 +17,13 @@ try:
 except:
     frame_type = None
 
+try:
+    long
+    unicode
+except NameError:
+    long = int
+    unicode = str
+
 
 def make_valid_xml_value(s):
     # Same thing as xml.sax.saxutils.escape but also escaping double quotes.

--- a/build_tools/rename_pep8.py
+++ b/build_tools/rename_pep8.py
@@ -1,6 +1,7 @@
 '''
 Helper module to do refactoring to convert names to pep8.
 '''
+from __future__ import print_function
 import re
 import os
 import names_to_rename
@@ -33,8 +34,8 @@ def find_matches():
     found = set()
     for path, initial_contents in iter_files_in_dir(os.path.dirname(os.path.dirname(__file__))):
         found.update(find_matches_in_contents(initial_contents))
-    print '\n'.join(sorted(found))
-    print 'Total', len(found)
+    print('\n'.join(sorted(found)))
+    print('Total', len(found))
 
 def substitute_contents(re_name_to_new_val, initial_contents):
     contents = initial_contents
@@ -48,7 +49,7 @@ def make_replace():
     for path, initial_contents in iter_files_in_dir(os.path.dirname(os.path.dirname(__file__))):
         contents = substitute_contents(re_name_to_new_val, initial_contents)
         if contents != initial_contents:
-            print 'Changed something at: %s' % (path,)
+            print('Changed something at: %s' % (path,))
 
             for val in re_name_to_new_val.itervalues():
                 # Check in initial contents to see if it already existed!

--- a/interpreterInfo.py
+++ b/interpreterInfo.py
@@ -32,6 +32,10 @@ except:  # ImportError or AttributeError.
             return a + b
         return a + '/' + b
 
+try:
+    unicode
+except NameError:
+    unicode = str
 
 IS_PYTHON_3_ONWARDS = 0
 
@@ -45,8 +49,8 @@ try:
     # Just check if False and True are defined (depends on version, not whether it's jython/python)
     False
     True
-except:
-    exec ('True, False = 1,0')  # An exec is used so that python 3k does not give a syntax error
+except NameError:
+    exec('True, False = 1, 0')  # An exec is used so that python 3k does not give a syntax error
 
 if sys.platform == "cygwin":
 

--- a/pydev_coverage.py
+++ b/pydev_coverage.py
@@ -1,6 +1,10 @@
 '''
 Entry point module to run code-coverage.
 '''
+try:
+    raw_input
+except NameError:
+    raw_input = input
 
 
 def is_valid_py_file(path):

--- a/pydevd_attach_to_process/_check.py
+++ b/pydevd_attach_to_process/_check.py
@@ -1,2 +1,3 @@
+from __future__ import print_function
 import add_code_to_python_process
-print add_code_to_python_process.run_python_code(3736, "print(20)", connect_debugger_tracing=False)
+print(add_code_to_python_process.run_python_code(3736, "print(20)", connect_debugger_tracing=False))

--- a/pydevd_attach_to_process/winappdbg/breakpoint.py
+++ b/pydevd_attach_to_process/winappdbg/breakpoint.py
@@ -73,6 +73,11 @@ import ctypes
 import warnings
 import traceback
 
+try:
+    long
+except NameError:
+    long = int
+
 #==============================================================================
 
 class BreakpointWarning (UserWarning):

--- a/pydevd_attach_to_process/winappdbg/compat.py
+++ b/pydevd_attach_to_process/winappdbg/compat.py
@@ -33,20 +33,29 @@ import types
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
-if PY3:
+try:
+    string_types = basestring,
+    integer_types = (int, long)
+    unichr = unichr
+    unicode = unicode
+    xrange = xrange
+except NameError:
     string_types = str,
     integer_types = int,
+    unicode = str
+    unichr = chr
+    xrange = range
+
+text_type = unicode
+
+if PY3:
     class_types = type,
-    text_type = str
-    binary_type = bytes
+    binary_type = bytes = bytes
 
     MAXSIZE = sys.maxsize
 else:
-    string_types = basestring,
-    integer_types = (int, long)
     class_types = (type, types.ClassType)
-    text_type = unicode
-    binary_type = str
+    binary_type = bytes = str
 
     if sys.platform.startswith("java"):
         # Jython always uses 32 bits.
@@ -68,9 +77,6 @@ else:
 
 
 if PY3:
-    xrange = range
-    unicode = str
-    bytes = bytes
     def iterkeys(d, **kw):
         if hasattr(d, 'iterkeys'):
             return iter(d.iterkeys(**kw))
@@ -94,9 +100,6 @@ if PY3:
     def keys(d, **kw):
         return list(iterkeys(d, **kw))
 else:
-    unicode = unicode
-    xrange = xrange
-    bytes = str
     def keys(d, **kw):
         return d.keys(**kw)
 
@@ -152,7 +155,6 @@ if PY3:
         return s
     def u(s):
         return s
-    unichr = chr
     if sys.version_info[1] <= 1:
         def int2byte(i):
             return bytes((i,))
@@ -171,7 +173,6 @@ else:
     # Workaround for standalone backslash
     def u(s):
         return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
-    unichr = unichr
     int2byte = chr
     def byte2int(bs):
         return ord(bs[0])

--- a/pydevd_attach_to_process/winappdbg/debug.py
+++ b/pydevd_attach_to_process/winappdbg/debug.py
@@ -56,6 +56,8 @@ from winappdbg.interactive import ConsoleDebugger
 import warnings
 ##import traceback
 
+from . import compat
+
 #==============================================================================
 
 # If you set this warning to be considered as an error, you can stop the

--- a/pydevd_attach_to_process/winappdbg/event.py
+++ b/pydevd_attach_to_process/winappdbg/event.py
@@ -106,6 +106,11 @@ import ctypes
 import warnings
 import traceback
 
+try:
+    long
+except NameError:
+    long = int
+
 #==============================================================================
 
 class EventCallbackWarning (RuntimeWarning):

--- a/pydevd_attach_to_process/winappdbg/interactive.py
+++ b/pydevd_attach_to_process/winappdbg/interactive.py
@@ -69,6 +69,16 @@ import traceback
 # too many variables named "cmd" to have a module by the same name :P
 from cmd import Cmd
 
+try:
+    raw_input
+except NameError:
+    raw_input = input
+
+try:
+    reload
+except NameError:
+    from importlib import reload
+
 # lazy imports
 readline = None
 

--- a/pydevd_attach_to_process/winappdbg/module.py
+++ b/pydevd_attach_to_process/winappdbg/module.py
@@ -38,7 +38,7 @@ Module instrumentation.
     DebugSymbolsWarning
 """
 
-from __future__ import with_statement
+from __future__ import unicode_literals, with_statement
 
 __revision__ = "$Id$"
 
@@ -56,6 +56,11 @@ Process = None
 import os
 import warnings
 import traceback
+
+try:
+    long
+except NameError:
+    long = int
 
 #==============================================================================
 

--- a/pydevd_attach_to_process/winappdbg/plugins/do_example.py
+++ b/pydevd_attach_to_process/winappdbg/plugins/do_example.py
@@ -30,12 +30,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 __revision__ = "$Id$"
 
 def do(self, arg):
     ".example - This is an example plugin for the command line debugger"
-    print "This is an example command."
-    print "%s.do(%r, %r):" % (__name__, self, arg)
-    print "  last event", self.lastEvent
-    print "  prefix", self.cmdprefix
-    print "  arguments", self.split_tokens(arg)
+    print("This is an example command.")
+    print("%s.do(%r, %r):" % (__name__, self, arg))
+    print("  last event", self.lastEvent)
+    print("  prefix", self.cmdprefix)
+    print("  arguments", self.split_tokens(arg))

--- a/pydevd_attach_to_process/winappdbg/plugins/do_exchain.py
+++ b/pydevd_attach_to_process/winappdbg/plugins/do_exchain.py
@@ -30,6 +30,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 __revision__ = "$Id$"
 
 from winappdbg import HexDump, Table
@@ -37,8 +38,8 @@ from winappdbg import HexDump, Table
 def do(self, arg):
     ".exchain - Show the SEH chain"
     thread = self.get_thread_from_prefix()
-    print "Exception handlers for thread %d" % thread.get_tid()
-    print
+    print("Exception handlers for thread %d" % thread.get_tid())
+    print()
     table = Table()
     table.addRow("Block", "Function")
     bits = thread.get_bits()
@@ -48,4 +49,4 @@ def do(self, arg):
         if seh_func is not None:
             seh_func = HexDump.address(seh_func, bits)
         table.addRow(seh, seh_func)
-    print table.getOutput()
+    print(table.getOutput())

--- a/pydevd_attach_to_process/winappdbg/plugins/do_exploitable.py
+++ b/pydevd_attach_to_process/winappdbg/plugins/do_exploitable.py
@@ -30,6 +30,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 __revision__ = "$Id$"
 
 def do(self, arg):
@@ -43,8 +44,8 @@ def do(self, arg):
 
     status, rule, description = crash.isExploitable()
 
-    print "-" * 79
-    print "Exploitability: %s" % status
-    print "Matched rule:   %s" % rule
-    print "Description:    %s" % description
-    print "-" * 79
+    print("-" * 79)
+    print("Exploitability: %s" % status)
+    print("Matched rule:   %s" % rule)
+    print("Description:    %s" % description)
+    print("-" * 79)

--- a/pydevd_attach_to_process/winappdbg/process.py
+++ b/pydevd_attach_to_process/winappdbg/process.py
@@ -70,6 +70,11 @@ import traceback
 # delayed import
 System = None
 
+try:
+    long
+except NameError:
+    long = int
+
 #==============================================================================
 
 # TODO

--- a/pydevd_attach_to_process/winappdbg/search.py
+++ b/pydevd_attach_to_process/winappdbg/search.py
@@ -64,6 +64,8 @@ try:
 except ImportError:
     import re
 
+from . import compat
+
 #==============================================================================
 
 class Pattern (object):

--- a/pydevd_attach_to_process/winappdbg/sql.py
+++ b/pydevd_attach_to_process/winappdbg/sql.py
@@ -58,6 +58,8 @@ from crash import Crash, Marshaller, pickle, HIGHEST_PROTOCOL
 from textio import CrashDump
 import win32
 
+from . import compat
+
 #------------------------------------------------------------------------------
 
 try:

--- a/pydevd_attach_to_process/winappdbg/textio.py
+++ b/pydevd_attach_to_process/winappdbg/textio.py
@@ -41,6 +41,7 @@ Functions for text input, logging or text output.
     DebugLog
     CrashDump
 """
+from __future__ import print_function
 
 __revision__ = "$Id$"
 
@@ -401,7 +402,7 @@ class HexOutput (StaticClass):
         """
         fd = open(filename, 'w')
         for integer in values:
-            print >> fd, cls.integer(integer, bits)
+            print(cls.integer(integer, bits), file=fd)
         fd.close()
 
     @classmethod
@@ -420,7 +421,7 @@ class HexOutput (StaticClass):
         """
         fd = open(filename, 'w')
         for string in values:
-            print >> fd, string
+            print(string, file=fd)
         fd.close()
 
     @classmethod
@@ -448,7 +449,7 @@ class HexOutput (StaticClass):
                 parsed = cls.integer(original, bits)
             except TypeError:
                 parsed = repr(original)
-            print >> fd, parsed
+            print(parsed, file=fd)
         fd.close()
 
 #------------------------------------------------------------------------------

--- a/pydevd_attach_to_process/winappdbg/util.py
+++ b/pydevd_attach_to_process/winappdbg/util.py
@@ -769,7 +769,7 @@ class DebugRegister (StaticClass):
     disableMask = tuple( [_registerMask ^ x for x in enableMask] ) # The registerMask from the class is not there in py3
     try:
         del x # It's not there in py3
-    except:
+    except NameError:
         pass
 
     # orMask, andMask = triggerMask[register][trigger]

--- a/pydevd_plugins/django_debug.py
+++ b/pydevd_plugins/django_debug.py
@@ -20,6 +20,10 @@ try:
 except:
     pass
 
+try:
+    unicode
+except NameError: 
+    unicode = str
 
 class DjangoLineBreakpoint(LineBreakpoint):
 

--- a/pydevd_plugins/jinja2_debug.py
+++ b/pydevd_plugins/jinja2_debug.py
@@ -6,6 +6,11 @@ from pydevd_file_utils import canonical_normalized_path
 from _pydevd_bundle.pydevd_frame_utils import add_exception_to_frame, FCode
 from _pydev_bundle import pydev_log
 
+try:
+    unicode
+except NameError: 
+    unicode = str
+
 
 class Jinja2LineBreakpoint(LineBreakpoint):
 

--- a/runfiles.py
+++ b/runfiles.py
@@ -9,7 +9,7 @@ import os
 
 try:
     xrange
-except:
+except ImportError:
     xrange = range
 
 def main():

--- a/runfiles.py
+++ b/runfiles.py
@@ -9,7 +9,7 @@ import os
 
 try:
     xrange
-except ImportError:
+except NameError:
     xrange = range
 
 def main():

--- a/stubs/_get_tips.py
+++ b/stubs/_get_tips.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os.path
 import inspect
 import sys
@@ -280,4 +281,4 @@ def %(method_name)s%(args)s:
         for line in doc.splitlines():
             lines.append('    ' + line)
         doc = '\n'.join(lines)
-        print temp % dict(method_name=entry[0], args=entry[2] or '(self)', doc=doc)
+        print(temp % dict(method_name=entry[0], args=entry[2] or '(self)', doc=doc))

--- a/tests/test_pydev_ipython_011.py
+++ b/tests/test_pydev_ipython_011.py
@@ -12,7 +12,7 @@ import pytest
 
 try:
     xrange
-except:
+except NameError:
     xrange = range
 
 def eq_(a, b):

--- a/tests/test_simpleTipper.py
+++ b/tests/test_simpleTipper.py
@@ -66,17 +66,17 @@ class TestCPython(unittest.TestCase):
     def test_imports2b(self):
         try:
             file
-        except:
+        except NameError:
             pass
         else:
             tips = _pydev_imports_tipper.generate_tip('%s' % BUILTIN_MOD)
-            t = self.assert_in('file' , tips)
+            t = self.assert_in('file', tips)
             self.assertTrue('->' in t[1].strip() or 'file' in t[1])
 
     def test_imports2c(self):
         try:
             file  # file is not available on py 3
-        except:
+        except NameError:
             pass
         else:
             tips = _pydev_imports_tipper.generate_tip('%s.file' % BUILTIN_MOD)


### PR DESCRIPTION
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.