### PR TITLE
Add support for `pydevd --continue` to allow launching an app without pausing

### DIFF
--- a/_pydevd_bundle/pydevd_command_line_handling.py
+++ b/_pydevd_bundle/pydevd_command_line_handling.py
@@ -69,6 +69,7 @@ ACCEPTED_ARG_HANDLERS = [
     ArgHandlerWithParam('client-access-token'),
 
     ArgHandlerBool('server'),
+    ArgHandlerBool('continue'),
     ArgHandlerBool('DEBUG_RECORD_SOCKET_READS'),
     ArgHandlerBool('multiproc'),  # Used by PyCharm (reuses connection: ssh tunneling)
     ArgHandlerBool('multiprocess'),  # Used by PyDev (creates new connection to ide)

--- a/pydevd.py
+++ b/pydevd.py
@@ -1377,7 +1377,7 @@ class PyDB(object):
         def run(self):
             host = SetupHolder.setup['client']
             if host is None:
-                host = 'localhost'
+                host = ''
             port = SetupHolder.setup['port']
 
             self._server_socket = create_server_socket(host=host, port=port)

--- a/pydevd.py
+++ b/pydevd.py
@@ -3276,14 +3276,21 @@ def main():
 
         apply_debugger_options(setup)
 
+        wait = True
+        if setup['continue']:
+            wait = False
+
         try:
-            debugger.connect(host, port)
+            if wait:
+                debugger.connect(host, port)
+            else:
+                debugger.create_wait_for_connection_thread()
         except:
             sys.stderr.write("Could not connect to %s: %s\n" % (host, port))
             pydev_log.exception()
             sys.exit(1)
 
-        globals = debugger.run(setup['file'], None, None, is_module)
+        globals = debugger.run(setup['file'], None, None, is_module, set_trace=wait)
 
         if setup['cmd-line']:
             debugger.wait_for_commands(globals)

--- a/pydevd.py
+++ b/pydevd.py
@@ -1376,6 +1376,8 @@ class PyDB(object):
 
         def run(self):
             host = SetupHolder.setup['client']
+            if host is None:
+                host = 'localhost'
             port = SetupHolder.setup['port']
 
             self._server_socket = create_server_socket(host=host, port=port)
@@ -2240,7 +2242,7 @@ class PyDB(object):
         from _pydev_bundle.pydev_monkey import patch_thread_modules
         patch_thread_modules()
 
-    def run(self, file, globals=None, locals=None, is_module=False, set_trace=True):
+    def run(self, file, globals=None, locals=None, is_module=False, set_trace=True, wait=True):
         module_name = None
         entry_point_fn = ''
         if is_module:
@@ -2322,7 +2324,8 @@ class PyDB(object):
             sys.path.insert(0, os.path.split(os_path_abspath(file))[0])
 
         if set_trace:
-            self.wait_for_ready_to_run()
+            if wait:
+                self.wait_for_ready_to_run()
 
             # call prepare_to_run when we already have all information about breakpoints
             self.prepare_to_run()
@@ -3290,7 +3293,7 @@ def main():
             pydev_log.exception()
             sys.exit(1)
 
-        globals = debugger.run(setup['file'], None, None, is_module, set_trace=wait)
+        globals = debugger.run(setup['file'], None, None, is_module, wait=wait)
 
         if setup['cmd-line']:
             debugger.wait_for_commands(globals)


### PR DESCRIPTION
This PR adds a new flag to `pydevd`, `--continue`, to start the application without waiting for the debugger connection.  @etanshaul has been testing this with PyCharm with good results.

I didn't find an obvious place to create a test around this and would appreciate a pointer for how to proceed.

Fixes #161