### PR TITLE
Re-enable Cython support for Stackless Python

### DIFF
--- a/_pydevd_bundle/pydevd_constants.py
+++ b/_pydevd_bundle/pydevd_constants.py
@@ -164,7 +164,7 @@ IS_PYTHON_STACKLESS = "stackless" in sys.version.lower()
 CYTHON_SUPPORTED = False
 
 python_implementation = platform.python_implementation()
-if python_implementation == 'CPython' and not IS_PYTHON_STACKLESS:
+if python_implementation == 'CPython':
     # Only available for CPython!
     if (
         (sys.version_info[0] == 2 and sys.version_info[1] >= 6)


### PR DESCRIPTION
Cython speedups were disabled in April 2017 (commit 5ea0f3b1), because of Cython bugs that were fixed in August 2018
(https://github.com/cython/cython/pull/2554 and https://github.com/cython/cython/pull/2556). And all Stackless versions
released after August 2018 contain a workaround for this bug. Therefore it is now time to re-enable Cython speedups for Stackless Python.