### PR TITLE
Add explicit encoding to open calls in pydevd_api.py

### DIFF
--- a/_pydevd_bundle/pydevd_api.py
+++ b/_pydevd_bundle/pydevd_api.py
@@ -44,7 +44,7 @@ else:
     def _get_code_lines(code):
         if not isinstance(code, types.CodeType):
             path = code
-            with open(path) as f:
+            with open(path, encoding='utf-8') as f:
                 src = f.read()
             code = compile(src, path, 'exec', 0, dont_inherit=True)
             return _get_code_lines(code)
@@ -725,7 +725,7 @@ class PyDevdAPI(object):
             filename = self.filename_to_server(filename)
             assert filename.__class__ == str  # i.e.: bytes on py2 and str on py3
 
-            with open(filename, 'r') as stream:
+            with open(filename, 'r', encoding='utf-8') as stream:
                 source = stream.read()
             cmd = py_db.cmd_factory.make_load_source_message(seq, source)
         except:


### PR DESCRIPTION
Without it, users on 3.10 with PYTHONWARNDEFAULTENCODING set (such as myself) get chatty EncodingWarnings :)