### PR TITLE
bugfix: Support PathLike objects for subprocess

### DIFF
--- a/_pydev_bundle/pydev_monkey.py
+++ b/_pydev_bundle/pydev_monkey.py
@@ -250,6 +250,8 @@ def _get_str_type_compatible(s, args):
 # Things related to monkey-patching
 #===============================================================================
 def is_python(path):
+    if isinstance(path, os.PathLike):
+        path = path.__fspath__()
     single_quote, double_quote = _get_str_type_compatible(path, ["'", '"'])
 
     if path.endswith(single_quote) or path.endswith(double_quote):


### PR DESCRIPTION
This fixes https://youtrack.jetbrains.com/issue/PY-48506/error-on-pydevmonkey-in-debug-mode-AttributeError-PosixPath-object-has-no-attribute-endswith by checking if the path is PathLike, and calling __fspath__() to get the string version of the path.