### PR TITLE
Replace deprecated threading.currentThread with threading.current_thread

### DIFF
--- a/_pydevd_bundle/pydevd_cython.c
+++ b/_pydevd_bundle/pydevd_cython.c
@@ -24634,7 +24634,7 @@ static PyObject *__pyx_pf_14_pydevd_bundle_13pydevd_cython_6fix_top_level_trace_
  *                 return None, False
  * 
  *             elif f_unhandled.f_code.co_name in ('__bootstrap_inner', '_bootstrap_inner'):             # <<<<<<<<<<<<<<
- *                 # Note: be careful not to use threading.currentThread to avoid creating a dummy thread.
+ *                 # Note: be careful not to use threading.current_thread to avoid creating a dummy thread.
  *                 t = f_unhandled.f_locals.get('self')
  */
       __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_f_unhandled, __pyx_n_s_f_code); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1414, __pyx_L1_error)
@@ -24657,7 +24657,7 @@ static PyObject *__pyx_pf_14_pydevd_bundle_13pydevd_cython_6fix_top_level_trace_
 
         /* "_pydevd_bundle/pydevd_cython.pyx":1416
  *             elif f_unhandled.f_code.co_name in ('__bootstrap_inner', '_bootstrap_inner'):
- *                 # Note: be careful not to use threading.currentThread to avoid creating a dummy thread.
+ *                 # Note: be careful not to use threading.current_thread to avoid creating a dummy thread.
  *                 t = f_unhandled.f_locals.get('self')             # <<<<<<<<<<<<<<
  *                 force_only_unhandled_tracer = True
  *                 if t is not None and isinstance(t, threading.Thread):
@@ -24686,7 +24686,7 @@ static PyObject *__pyx_pf_14_pydevd_bundle_13pydevd_cython_6fix_top_level_trace_
         __pyx_t_4 = 0;
 
         /* "_pydevd_bundle/pydevd_cython.pyx":1417
- *                 # Note: be careful not to use threading.currentThread to avoid creating a dummy thread.
+ *                 # Note: be careful not to use threading.current_thread to avoid creating a dummy thread.
  *                 t = f_unhandled.f_locals.get('self')
  *                 force_only_unhandled_tracer = True             # <<<<<<<<<<<<<<
  *                 if t is not None and isinstance(t, threading.Thread):
@@ -24752,7 +24752,7 @@ static PyObject *__pyx_pf_14_pydevd_bundle_13pydevd_cython_6fix_top_level_trace_
  *                 return None, False
  * 
  *             elif f_unhandled.f_code.co_name in ('__bootstrap_inner', '_bootstrap_inner'):             # <<<<<<<<<<<<<<
- *                 # Note: be careful not to use threading.currentThread to avoid creating a dummy thread.
+ *                 # Note: be careful not to use threading.current_thread to avoid creating a dummy thread.
  *                 t = f_unhandled.f_locals.get('self')
  */
       }

--- a/_pydevd_bundle/pydevd_cython.pyx
+++ b/_pydevd_bundle/pydevd_cython.pyx
@@ -1412,7 +1412,7 @@ def fix_top_level_trace_and_get_trace_func(py_db, frame):
                 return None, False
 
             elif f_unhandled.f_code.co_name in ('__bootstrap_inner', '_bootstrap_inner'):
-                # Note: be careful not to use threading.currentThread to avoid creating a dummy thread.
+                # Note: be careful not to use threading.current_thread to avoid creating a dummy thread.
                 t = f_unhandled.f_locals.get('self')
                 force_only_unhandled_tracer = True
                 if t is not None and isinstance(t, threading.Thread):

--- a/_pydevd_bundle/pydevd_trace_dispatch_regular.py
+++ b/_pydevd_bundle/pydevd_trace_dispatch_regular.py
@@ -107,7 +107,7 @@ def fix_top_level_trace_and_get_trace_func(py_db, frame):
                 return None, False
 
             elif f_unhandled.f_code.co_name in ('__bootstrap_inner', '_bootstrap_inner'):
-                # Note: be careful not to use threading.currentThread to avoid creating a dummy thread.
+                # Note: be careful not to use threading.current_thread to avoid creating a dummy thread.
                 t = f_unhandled.f_locals.get('self')
                 force_only_unhandled_tracer = True
                 if t is not None and isinstance(t, threading.Thread):

--- a/_pydevd_frame_eval/pydevd_frame_evaluator.c
+++ b/_pydevd_frame_eval/pydevd_frame_evaluator.c
@@ -2703,7 +2703,7 @@ static PyObject *__pyx_f_18_pydevd_frame_eval_22pydevd_frame_evaluator_10ThreadI
  *         # print('Can create dummy thread for thread started in: %s %s' % (basename, co_name))
  * 
  *     cdef initialize_if_possible(self):             # <<<<<<<<<<<<<<
- *         # Don't call threading.currentThread because if we're too early in the process
+ *         # Don't call threading.current_thread because if we're too early in the process
  *         # we may create a dummy thread.
  */
 
@@ -2739,7 +2739,7 @@ static PyObject *__pyx_f_18_pydevd_frame_eval_22pydevd_frame_evaluator_10ThreadI
   __Pyx_RefNannySetupContext("initialize_if_possible", 0);
 
   /* "_pydevd_frame_eval/pydevd_frame_evaluator.pyx":89
- *         # Don't call threading.currentThread because if we're too early in the process
+ *         # Don't call threading.current_thread because if we're too early in the process
  *         # we may create a dummy thread.
  *         self.inside_frame_eval += 1             # <<<<<<<<<<<<<<
  * 
@@ -3359,7 +3359,7 @@ static PyObject *__pyx_f_18_pydevd_frame_eval_22pydevd_frame_evaluator_10ThreadI
  *         # print('Can create dummy thread for thread started in: %s %s' % (basename, co_name))
  * 
  *     cdef initialize_if_possible(self):             # <<<<<<<<<<<<<<
- *         # Don't call threading.currentThread because if we're too early in the process
+ *         # Don't call threading.current_thread because if we're too early in the process
  *         # we may create a dummy thread.
  */
 

--- a/_pydevd_frame_eval/pydevd_frame_evaluator.template.pyx
+++ b/_pydevd_frame_eval/pydevd_frame_evaluator.template.pyx
@@ -84,7 +84,7 @@ cdef class ThreadInfo:
         # print('Can create dummy thread for thread started in: %s %s' % (basename, co_name))
 
     cdef initialize_if_possible(self):
-        # Don't call threading.currentThread because if we're too early in the process
+        # Don't call threading.current_thread because if we're too early in the process
         # we may create a dummy thread.
         self.inside_frame_eval += 1
 

--- a/pydevd.py
+++ b/pydevd.py
@@ -681,7 +681,7 @@ class PyDB(object):
             except:
                 self.threading_get_ident = None  # Jython
                 self.threading_active = None
-        self.threading_current_thread = threading.currentThread
+        self.threading_current_thread = threading.current_thread
         self.set_additional_thread_info = set_additional_thread_info
         self.stop_on_unhandled_exception = stop_on_unhandled_exception
         self.collect_return_info = collect_return_info


### PR DESCRIPTION
`threading.currentThread` was deprecated in Python 3.10 (October 2021).

Replace with `threading.current_thread`, added in Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174