### PR TITLE
Protect test test_case_15 against "+" in filenames

### DIFF
--- a/tests_python/debugger_unittest.py
+++ b/tests_python/debugger_unittest.py
@@ -1290,7 +1290,7 @@ class AbstractWriterThread(threading.Thread):
 
     def write_custom_operation(self, locator, style, codeOrFile, operation_fn_name):
         self.write("%s\t%s\t%s||%s\t%s\t%s" % (
-            CMD_RUN_CUSTOM_OPERATION, self.next_seq(), locator, style, codeOrFile, operation_fn_name))
+            CMD_RUN_CUSTOM_OPERATION, self.next_seq(), locator, style, quote_plus(codeOrFile), operation_fn_name))
 
     def write_evaluate_expression(self, locator, expression):
         self.write("%s\t%s\t%s\t%s\t1" % (CMD_EVALUATE_EXPRESSION, self.next_seq(), locator, expression))


### PR DESCRIPTION
This small patch to the test suite fixes #220 - it turns out that this is only an issue in the test suite, not in the rest of the code.  The problem is that the filename has `unquote_plus` applied to it, but never had `quote_plus` applied.  This patch has been tested with directory names both including and excluding a "+" character.

I also tried a directory name containing a space, and that worked fine with this test but broke `tests.test_pydev_ipython_011.TestRunningCode testMethod=test_edit`.  But that, I guess, is a separate issue...