### PR TITLE
Change DebuggerInitializationError to subclass Exception

### DIFF
--- a/_pydev_bundle/_pydev_saved_modules.py
+++ b/_pydev_bundle/_pydev_saved_modules.py
@@ -21,7 +21,7 @@ def find_in_pythonpath(module_name):
     return found_at
 
 
-class DebuggerInitializationError(BaseException):
+class DebuggerInitializationError(Exception):
     pass
 
 


### PR DESCRIPTION
Per PEP8[1] and the Python docs[2], custom exceptions defined in library
code should not normally derive from BaseException, which is reserved
for exceptions that should not normally be caught (e.g.
`KeyboardInterrupt`, `SystemExit`). Deriving from BaseException makes it
difficult for application code to catch and reraise this exception
safely.

[1] https://peps.python.org/pep-0008/#programming-recommendations
[2] https://docs.python.org/3/library/exceptions.html#Exception