### PR TITLE
Make sure SO_REUSEADDR is available on windows

### DIFF
--- a/_pydevd_bundle/pydevd_comm.py
+++ b/_pydevd_bundle/pydevd_comm.py
@@ -124,7 +124,7 @@ AF_INET, SOCK_STREAM, SHUT_WR, SOL_SOCKET, IPPROTO_TCP, socket = (
 
 if IS_WINDOWS and not IS_JYTHON:
     SO_EXCLUSIVEADDRUSE = socket_module.SO_EXCLUSIVEADDRUSE
-elif not IS_WASM:
+if not IS_WASM:
     SO_REUSEADDR = socket_module.SO_REUSEADDR
 
 class ReaderThread(PyDBDaemonThread):


### PR DESCRIPTION
Don't use an elif. Only on WASM builds should this be skipped