### PR TITLE
Add support for qt6 (PyQt6 and PySide6)

### DIFF
--- a/_pydev_bundle/pydev_monkey_qt.py
+++ b/_pydev_bundle/pydev_monkey_qt.py
@@ -18,7 +18,7 @@ _patched_qt = False
 
 def patch_qt(qt_support_mode):
     '''
-    This method patches qt (PySide2, PySide, PyQt4, PyQt5) so that we have hooks to set the tracing for QThread.
+    This method patches qt (PySide6, PySide2, PySide, PyQt4, PyQt5, PyQt6) so that we have hooks to set the tracing for QThread.
     '''
     if not qt_support_mode:
         return
@@ -43,24 +43,38 @@ def patch_qt(qt_support_mode):
 
         patch_qt_on_import = None
         try:
-            import PySide2  # @UnresolvedImport @UnusedImport
-            qt_support_mode = 'pyside2'
+            import PySide6  # @UnresolvedImport @UnusedImport
+            qt_support_mode = 'pyside6'
         except:
             try:
-                import Pyside  # @UnresolvedImport @UnusedImport
-                qt_support_mode = 'pyside'
+                import PySide2  # @UnresolvedImport @UnusedImport
+                qt_support_mode = 'pyside2'
             except:
                 try:
-                    import PyQt5  # @UnresolvedImport @UnusedImport
-                    qt_support_mode = 'pyqt5'
+                    import Pyside  # @UnresolvedImport @UnusedImport
+                    qt_support_mode = 'pyside'
                 except:
                     try:
-                        import PyQt4  # @UnresolvedImport @UnusedImport
-                        qt_support_mode = 'pyqt4'
+                        import PyQt6  # @UnresolvedImport @UnusedImport
+                        qt_support_mode = 'pyqt6'
                     except:
-                        return
+                        try:
+                            import PyQt5  # @UnresolvedImport @UnusedImport
+                            qt_support_mode = 'pyqt5'
+                        except:
+                            try:
+                                import PyQt4  # @UnresolvedImport @UnusedImport
+                                qt_support_mode = 'pyqt4'
+                            except:
+                                return
+    if qt_support_mode == 'pyside6':
+        try:
+            import PySide6.QtCore  # @UnresolvedImport
+            _internal_patch_qt(PySide6.QtCore, qt_support_mode)
+        except:
+            return
 
-    if qt_support_mode == 'pyside2':
+    elif qt_support_mode == 'pyside2':
         try:
             import PySide2.QtCore  # @UnresolvedImport
             _internal_patch_qt(PySide2.QtCore, qt_support_mode)
@@ -71,6 +85,13 @@ def patch_qt(qt_support_mode):
         try:
             import PySide.QtCore  # @UnresolvedImport
             _internal_patch_qt(PySide.QtCore, qt_support_mode)
+        except:
+            return
+        
+    elif qt_support_mode == 'pyqt6':
+        try:
+            import PyQt6.QtCore  # @UnresolvedImport
+            _internal_patch_qt(PyQt6.QtCore)
         except:
             return
 
@@ -155,14 +176,14 @@ def _internal_patch_qt(QtCore, qt_support_mode='auto'):
             QtCore.QObject.__init__(self)
             self.thread = thread
             self.original_started = original_started
-            if qt_support_mode in ('pyside', 'pyside2'):
+            if qt_support_mode in ('pyside', 'pyside2', 'pyside6'):
                 self._signal = original_started
             else:
                 self._signal.connect(self._on_call)
                 self.original_started.connect(self._signal)
 
         def connect(self, func, *args, **kwargs):
-            if qt_support_mode in ('pyside', 'pyside2'):
+            if qt_support_mode in ('pyside', 'pyside2', 'pyside6'):
                 return self._signal.connect(FuncWrapper(func), *args, **kwargs)
             else:
                 return self._signal.connect(func, *args, **kwargs)
@@ -193,7 +214,11 @@ def _internal_patch_qt(QtCore, qt_support_mode='auto'):
 
         def _exec_run(self):
             set_trace_in_qt()
-            self.exec_()
+            # Qt6: exec_ is deprecated/removed
+            if hasattr(self, 'exec'):
+                self.exec()
+            else:
+                self.exec_()
             return None
 
         def _new_run(self):

--- a/_pydevd_bundle/pydevd_command_line_handling.py
+++ b/_pydevd_bundle/pydevd_command_line_handling.py
@@ -151,13 +151,13 @@ def process_command_line(argv):
             # The --qt-support is special because we want to keep backward compatibility:
             # Previously, just passing '--qt-support' meant that we should use the auto-discovery mode
             # whereas now, if --qt-support is passed, it should be passed as --qt-support=<mode>, where
-            # mode can be one of 'auto', 'none', 'pyqt5', 'pyqt4', 'pyside', 'pyside2'.
+            # mode can be one of 'auto', 'none', 'pyqt6', 'pyqt5', 'pyqt4', 'pyside', 'pyside2', 'pyside6'.
             if argv[i] == '--qt-support':
                 setup['qt-support'] = 'auto'
 
             elif argv[i].startswith('--qt-support='):
                 qt_support = argv[i][len('--qt-support='):]
-                valid_modes = ('none', 'auto', 'pyqt5', 'pyqt4', 'pyside', 'pyside2')
+                valid_modes = ('none', 'auto', 'pyqt6', 'pyqt5', 'pyqt4', 'pyside', 'pyside2', 'pyside6')
                 if qt_support not in valid_modes:
                     raise ValueError("qt-support mode invalid: " + qt_support)
                 if qt_support == 'none':

--- a/tests_python/resources/_debugger_case_qthread1.py
+++ b/tests_python/resources/_debugger_case_qthread1.py
@@ -5,12 +5,18 @@ try:
     try:
         from PySide import QtCore  # @UnresolvedImport
     except:
-        from PySide2 import QtCore  # @UnresolvedImport
+        try:
+            from PySide2 import QtCore  # @UnresolvedImport
+        except:
+            from PySide6 import QtCore  # @UnresolvedImport
 except:
     try:
-        from PyQt4 import QtCore
+        from PyQt4 import QtCore # @UnresolvedImport
     except:
-        from PyQt5 import QtCore
+        try:
+            from PyQt5 import QtCore # @UnresolvedImport
+        except:
+            from PyQt6 import QtCore  # @UnresolvedImport
 
 # Subclassing QThread
 # http://doc.qt.nokia.com/latest/qthread.html
@@ -27,5 +33,9 @@ app = QtCore.QCoreApplication([])
 thread = AThread()
 thread.finished.connect(app.exit)
 thread.start()
-app.exec_()
+# Qt6: exec_ is deprecated/removed
+if hasattr(app, 'exec'):
+    app.exec()
+else:
+    app.exec_()
 print('TEST SUCEEDED!')

--- a/tests_python/resources/_debugger_case_qthread2.py
+++ b/tests_python/resources/_debugger_case_qthread2.py
@@ -5,12 +5,18 @@ try:
     try:
         from PySide import QtCore  # @UnresolvedImport
     except:
-        from PySide2 import QtCore  # @UnresolvedImport
+        try:
+            from PySide2 import QtCore  # @UnresolvedImport
+        except:
+            from PySide6 import QtCore  # @UnresolvedImport
 except:
     try:
-        from PyQt4 import QtCore
+        from PyQt4 import QtCore # @UnresolvedImport
     except:
-        from PyQt5 import QtCore
+        try:
+            from PyQt5 import QtCore # @UnresolvedImport
+        except:
+            from PyQt6 import QtCore  # @UnresolvedImport
 
 # Subclassing QObject and using moveToThread
 # http://labs.qt.nokia.com/2007/07/05/qthreads-no-longer-abstract/
@@ -36,5 +42,9 @@ obj.finished.connect(objThread.quit)
 objThread.started.connect(obj.long_running)
 objThread.finished.connect(app.exit)
 objThread.start()
-app.exec_()
+# Qt6: exec_ is deprecated/removed
+if hasattr(app, 'exec'):
+    app.exec()
+else:
+    app.exec_()
 print('TEST SUCEEDED!')

--- a/tests_python/resources/_debugger_case_qthread3.py
+++ b/tests_python/resources/_debugger_case_qthread3.py
@@ -5,12 +5,18 @@ try:
     try:
         from PySide import QtCore  # @UnresolvedImport
     except:
-        from PySide2 import QtCore  # @UnresolvedImport
+        try:
+            from PySide2 import QtCore  # @UnresolvedImport
+        except:
+            from PySide6 import QtCore  # @UnresolvedImport
 except:
     try:
-        from PyQt4 import QtCore
+        from PyQt4 import QtCore # @UnresolvedImport
     except:
-        from PyQt5 import QtCore
+        try:
+            from PyQt5 import QtCore # @UnresolvedImport
+        except:
+            from PyQt6 import QtCore  # @UnresolvedImport
 
 # Using a QRunnable
 # http://doc.qt.nokia.com/latest/qthreadpool.html
@@ -30,6 +36,10 @@ class Runnable(QtCore.QRunnable):
 app = QtCore.QCoreApplication([])
 runnable = Runnable()
 QtCore.QThreadPool.globalInstance().start(runnable)
-app.exec_()
+# Qt6: exec_ is deprecated/removed
+if hasattr(app, 'exec'):
+    app.exec()
+else:
+    app.exec_()
 QtCore.QThreadPool.globalInstance().waitForDone()
 print('TEST SUCEEDED!')

--- a/tests_python/resources/_debugger_case_qthread4.py
+++ b/tests_python/resources/_debugger_case_qthread4.py
@@ -1,13 +1,19 @@
 try:
-    from PySide import QtCore
-except:
     try:
-        from PySide2 import QtCore
+        from PySide import QtCore  # @UnresolvedImport
     except:
         try:
-            from PyQt4 import QtCore
+            from PySide2 import QtCore  # @UnresolvedImport
         except:
-            from PyQt5 import QtCore
+            from PySide6 import QtCore  # @UnresolvedImport
+except:
+    try:
+        from PyQt4 import QtCore # @UnresolvedImport
+    except:
+        try:
+            from PyQt5 import QtCore # @UnresolvedImport
+        except:
+            from PyQt6 import QtCore  # @UnresolvedImport
 
 
 class TestObject(QtCore.QObject):
@@ -30,7 +36,7 @@ class TestThread(QtCore.QThread):
 
 def on_start():
     print('On start called1')
-    print('On start called2')
+    print('On start called2') # break here
 
 
 app = QtCore.QCoreApplication([])
@@ -43,5 +49,9 @@ some_object.testSignal.connect(on_start)
 some_thread.finished.connect(app.quit)
 
 some_thread.start()
-app.exec_()
+# Qt6: exec_ is deprecated/removed
+if hasattr(app, 'exec'):
+    app.exec()
+else:
+    app.exec_()
 print('TEST SUCEEDED!')

--- a/tests_python/test_debugger.py
+++ b/tests_python/test_debugger.py
@@ -1163,8 +1163,12 @@ def _has_qt():
             from PySide import QtCore  # @UnresolvedImport
             return True
         except:
-            from PySide2 import QtCore  # @UnresolvedImport
-            return True
+            try:
+                from PySide2 import QtCore  # @UnresolvedImport
+                return True
+            except:
+                from PySide6 import QtCore  # @UnresolvedImport
+                return True
     except:
         try:
             from PyQt4 import QtCore  # @UnresolvedImport
@@ -1174,7 +1178,11 @@ def _has_qt():
                 from PyQt5 import QtCore  # @UnresolvedImport
                 return True
             except:
-                pass
+                try:
+                    from PyQt6 import QtCore  # @UnresolvedImport
+                    return True
+                except:
+                    pass
     return False
 
 
@@ -1249,7 +1257,7 @@ def test_case_qthread4(case_setup):
             if 'native Qt signal is not callable' in stderr:
                 raise AssertionError('Did not expect "native Qt signal is not callable" to be in stderr:\n%s' % (stderr,))
 
-        breakpoint_id = writer.write_add_breakpoint(28, 'on_start')  # breakpoint on print('On start called2').
+        breakpoint_id = writer.write_add_breakpoint(writer.get_line_index_with_content('break here'), 'on_start')  # breakpoint on print('On start called2').
         writer.write_make_initial_run()
 
         hit = writer.wait_for_breakpoint_hit()


### PR DESCRIPTION
Hello,
i added PySide6 and PyQt6 support to the `-qt-support` command line argument. The changes from qt5 to qt6 where quite minimal so I mostly added imports. The only relevant breaking change is the deprecation (PySide6) / removal (PyQt6) of `exec_()` in favor of `exec()` in `QThread`/`QCoreApplication`.
PyQt5 and PySide2 support both, so once Qt4 support is dropped, that additional check could be removed.

`test_case_qthread4` is failing for me with PySide2 and PySide6, so i dont think its actually related to my change. It works with PyQt6 though (only tested with those three).

I did not touch any of that pydev_ipython stuff, because i never really used IPython, but I had a quick look at the upstream sources in the IPython repo and they changed some other things, so it might be worth importing those again.