### PR TITLE
Add PYDEVD_REMOTE_ROOT support

### DIFF
--- a/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -319,6 +319,10 @@ class PyDevJsonCommandProcessor(object):
         self.api.request_completions(py_db, seq, thread_id, frame_id, text, line=line, column=column)
 
     def _resolve_remote_root(self, local_root, remote_root):
+        env_remote_root = os.environ.get("PYDEVD_REMOTE_ROOT", None)
+        if env_remote_root is not None:
+            return env_remote_root
+
         if remote_root == '.':
             cwd = os.getcwd()
             append_pathsep = local_root.endswith('\\') or local_root.endswith('/')


### PR DESCRIPTION
This change intends to fix https://github.com/microsoft/debugpy/issues/1130 by allowing for a env var (`PYDEVD_REMOTE_ROOT`) to unconditionally configure the remote root when set in the server's environment.