### PR TITLE
Pass `str` instead of `bytes` to `str.startswith` and `str.endswith` in winappdbg

### DIFF
--- a/pydevd_attach_to_process/winappdbg/util.py
+++ b/pydevd_attach_to_process/winappdbg/util.py
@@ -293,10 +293,10 @@ class PathOperations (StaticClass):
         # XXX TODO
         # There are probably some native paths that
         # won't be converted by this naive approach.
-        if name.startswith(compat.b("\\")):
-            if name.startswith(compat.b("\\??\\")):
+        if name.startswith("\\"):
+            if name.startswith("\\??\\"):
                 name = name[4:]
-            elif name.startswith(compat.b("\\SystemRoot\\")):
+            elif name.startswith("\\SystemRoot\\"):
                 system_root_path = os.environ['SYSTEMROOT']
                 if system_root_path.endswith('\\'):
                     system_root_path = system_root_path[:-1]
@@ -312,10 +312,10 @@ class PathOperations (StaticClass):
                                                  win32.ERROR_PATH_NOT_FOUND):
                             continue
                         raise
-                    if not device_native_path.endswith(compat.b('\\')):
-                        device_native_path += compat.b('\\')
+                    if not device_native_path.endswith('\\'):
+                        device_native_path += '\\'
                     if name.startswith(device_native_path):
-                        name = drive_letter + compat.b('\\') + \
+                        name = drive_letter + '\\' + \
                                               name[ len(device_native_path) : ]
                         break
         return name


### PR DESCRIPTION
In Python 3, `str.startswith` and `str.endswith`  methods no longer accept `bytes`, resulting in `TypeError: startswith first arg must be str or a tuple of str, not bytes`.

Corresponding issues in PyCharm:
- https://youtrack.jetbrains.com/issue/PY-47935/TypeError-endswith-first-arg-must-be-str-or-a-tuple-of-str-not-bytes
- https://youtrack.jetbrains.com/issue/PY-49421/TypeError-when-appending-a-directory-to-sys.path-and-attaching-to-process