### PR TITLE
If the arguments.breakpoints is not set, default to an empty list

### DIFF
--- a/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -742,6 +742,7 @@ class PyDevJsonCommandProcessor(object):
         expression = None
 
         breakpoints_set = []
+        arguments.breakpoints = arguments.breakpoints or []
         for bp in arguments.breakpoints:
             hit_condition = self._get_hit_condition_expression(bp.get('hitCondition'))
             condition = bp.get('condition')
@@ -784,7 +785,7 @@ class PyDevJsonCommandProcessor(object):
                 btype = 'jinja2-line'
 
         breakpoints_set = []
-
+        arguments.breakpoints = arguments.breakpoints or []
         for source_breakpoint in arguments.breakpoints:
             source_breakpoint = SourceBreakpoint(**source_breakpoint)
             line = source_breakpoint.line


### PR DESCRIPTION
According to the Debug Adapter Protocol, in the SetBreakpoints request, the 'breakpoints' field is optional and can be omitted in a JSON setBreakpoints message. pydevd should handle this case to adhere to the specification.