### PR TITLE
to display length/shape

### DIFF
--- a/pydevd_plugins/extensions/types/pydevd_plugin_sized_str.py
+++ b/pydevd_plugins/extensions/types/pydevd_plugin_sized_str.py
@@ -1,0 +1,20 @@
+from _pydevd_bundle.pydevd_extension_api import StrPresentationProvider
+from .pydevd_helpers import find_mod_attr
+
+
+class SizedShapeStr:
+    '''Displays the size of a Sized object before displaying its value.
+    '''
+    def can_provide(self, type_object, type_name):
+        sized_obj = find_mod_attr('collections.abc', 'Sized')
+        return sized_obj is not None and issubclass(type_object, sized_obj)
+
+    def get_str(self, val):
+        if hasattr(val, 'shape'):
+            return f'shape: {val.shape}, value: {val}'
+        return f'len: {len(val)}, value: {val}'
+
+import sys
+
+if not sys.platform.startswith("java"):
+    StrPresentationProvider.register(SizedShapeStr)


### PR DESCRIPTION
Displays the size of an Sized variable before displaying its value, such as `np.ndarray`, `torch.Tensor`. Can benefit ML/AI programming, as well as other programming that works heavily on large collections. Addressing https://github.com/microsoft/debugpy/issues/1525, https://github.com/microsoft/debugpy/issues/1191, etc.

![screenshot](https://private-user-images.githubusercontent.com/22453752/362576598-a6affeed-a6b5-454b-8c11-ec4449bda101.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjQ5ODQwODcsIm5iZiI6MTcyNDk4Mzc4NywicGF0aCI6Ii8yMjQ1Mzc1Mi8zNjI1NzY1OTgtYTZhZmZlZWQtYTZiNS00NTRiLThjMTEtZWM0NDQ5YmRhMTAxLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA4MzAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwODMwVDAyMDk0N1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWEzYzFmMGU4NGNkODg4YmZmYzY5YjQ2NjM0ZGE4NGYxMWFmM2M0ZGQ3M2I5NzUwNGY3YjU1YjcxM2UyNDUyOGEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.3K1YVfYtY1FlwON78chOZIFPMoJ9_M_JNmpYzXSzjco)