### PR TITLE
Do not use matplotlib deprecated functions

### DIFF
--- a/pydev_ipython/matplotlibtools.py
+++ b/pydev_ipython/matplotlibtools.py
@@ -55,11 +55,11 @@ def find_gui_and_backend():
 def is_interactive_backend(backend):
     """Check if backend is interactive"""
     matplotlib = sys.modules["matplotlib"]
-    from matplotlib.rcsetup import interactive_bk, non_interactive_bk  # @UnresolvedImport
+    from matplotlib.backends import BackendFilter, backend_registry  # @UnresolvedImport
 
-    if backend in interactive_bk:
+    if backend in backend_registry.list_builtin(BackendFilter.INTERACTIVE):
         return True
-    elif backend in non_interactive_bk:
+    elif backend in backend_registry.list_builtin(BackendFilter.NON_INTERACTIVE):
         return False
     else:
         return matplotlib.is_interactive()


### PR DESCRIPTION
I followed the recommendations from Matplotlib to replace `interative_bk` and `non_interactive_bk`:

```
matplotlib._api.deprecation.MatplotlibDeprecationWarning: The interactive_bk attribute was deprecated in Matplotlib 3.9 and will be removed in 3.11. Use ``matplotlib.backends.backend_registry.list_builtin(matplotlib.backends.BackendFilter.INTERACTIVE)`` instead.
```

I did manually testing by patching `matplotlibtools.py` of my `ms-python.debugpy` vscode extension. Feel free to take over the PR.

Closes #287