### PR TITLE
Don't change already suspended threads in subsequent suspend calls

### DIFF
--- a/_pydevd_bundle/pydevd_thread_lifecycle.py
+++ b/_pydevd_bundle/pydevd_thread_lifecycle.py
@@ -27,9 +27,9 @@ def pydevd_find_thread_by_id(thread_id):
 
 def mark_thread_suspended(thread, stop_reason: int, original_step_cmd: int = -1):
     info = set_additional_thread_info(thread)
-    info.suspend_type = PYTHON_SUSPEND
     if info.pydev_state != STATE_RUN:
         return info
+    info.suspend_type = PYTHON_SUSPEND
     if original_step_cmd != -1:
         stop_reason = original_step_cmd
     thread.stop_reason = stop_reason

--- a/_pydevd_bundle/pydevd_thread_lifecycle.py
+++ b/_pydevd_bundle/pydevd_thread_lifecycle.py
@@ -28,6 +28,8 @@ def pydevd_find_thread_by_id(thread_id):
 def mark_thread_suspended(thread, stop_reason: int, original_step_cmd: int = -1):
     info = set_additional_thread_info(thread)
     info.suspend_type = PYTHON_SUSPEND
+    if info.pydev_state != STATE_RUN:
+        return info
     if original_step_cmd != -1:
         stop_reason = original_step_cmd
     thread.stop_reason = stop_reason
@@ -92,6 +94,8 @@ def suspend_all_threads(py_db, except_thread):
             if t is except_thread:
                 continue
             info = mark_thread_suspended(t, CMD_THREAD_SUSPEND)
+            if info.pydev_state != STATE_SUSPEND:
+                continue
             frame = info.get_topmost_frame(t)
 
             # Reset the tracing as in this case as it could've set scopes to be untraced.

--- a/_pydevd_bundle/pydevd_thread_lifecycle.py
+++ b/_pydevd_bundle/pydevd_thread_lifecycle.py
@@ -25,9 +25,9 @@ def pydevd_find_thread_by_id(thread_id):
     return None
 
 
-def mark_thread_suspended(thread, stop_reason: int, original_step_cmd: int = -1):
+def mark_thread_suspended(thread, stop_reason: int, original_step_cmd: int = -1, skip_unless_run_state: bool = False):
     info = set_additional_thread_info(thread)
-    if info.pydev_state != STATE_RUN:
+    if skip_unless_run_state and info.pydev_state != STATE_RUN:
         return info
     info.suspend_type = PYTHON_SUSPEND
     if original_step_cmd != -1:
@@ -93,7 +93,7 @@ def suspend_all_threads(py_db, except_thread):
         else:
             if t is except_thread:
                 continue
-            info = mark_thread_suspended(t, CMD_THREAD_SUSPEND)
+            info = mark_thread_suspended(t, CMD_THREAD_SUSPEND, py_db.multi_threads_single_notification)
             if info.pydev_state != STATE_SUSPEND:
                 continue
             frame = info.get_topmost_frame(t)


### PR DESCRIPTION
Previously, already-suspended threads could still be modified by subsequent calls to `suspend_all_threads`. This change adds checks to prevent this.