### PR TITLE
Replace deprecated distutils

### DIFF
--- a/pydev_ipython/inputhook.py
+++ b/pydev_ipython/inputhook.py
@@ -147,11 +147,11 @@ class InputHookManager(object):
             app = wx.App(redirect=False, clearSigInt=False)
         """
         import wx
-        from distutils.version import LooseVersion as V
+        from packaging.version import Version as V
 
-        wx_version = V(wx.__version__).version  # @UndefinedVariable
+        wx_version = V(wx.__version__)  # @UndefinedVariable
 
-        if wx_version < [2, 8]:
+        if wx_version < V("2.8"):
             raise ValueError("requires wxPython >= 2.8, but you have %s" % wx.__version__)  # @UndefinedVariable
 
         from pydev_ipython.inputhookwx import inputhook_wx

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,8 @@ build_tools\pydevd_release_process.txt
 for release process.
 """
 
-from setuptools import setup
+from setuptools import Extension, setup
 from setuptools.dist import Distribution
-from distutils.extension import Extension
 import os
 
 

--- a/setup_pydevd_cython.py
+++ b/setup_pydevd_cython.py
@@ -181,7 +181,7 @@ def build_extension(dir_name, extension_name, target_pydevd_name, force_cython, 
                     stream.write(c_file_contents)
 
         # Always compile the .c (and not the .pyx) file (which we should keep up-to-date by running build_tools/build.py).
-        from distutils.extension import Extension
+        from setuptools import Extension
 
         extra_compile_args = []
         extra_link_args = []


### PR DESCRIPTION
This PR fixes #255 and #263, replacing the unprotected uses of distutils.  (There is one more occurrence in `build_tools/build.py`, but that is only a fallback.)

The patch to `pydev_ipython/inputhook.py` (which currently uses `LooseVersion`) requires importing `packaging`.  However, I would suggest that a better patch is to drop the version check entirely.  The changelog at https://github.com/wxWidgets/Phoenix/blob/master/CHANGES.rst says that `wxPython` version 2.8.0.1 was released in December 2006.  The chances of someone using a `PyDev.Debugger` version from 2025 together with a `wxPython` from 2006 or earlier is so remote that the check is pointless.

Best wishes,

Julian