### PR TITLE
Suppress warning on exit by properly closing `pydevd` socket

### DIFF
--- a/pydevd.py
+++ b/pydevd.py
@@ -724,6 +724,8 @@ class PyDB(object):
 
         self._local_thread_trace_func = threading.local()
 
+        self._client_socket = None
+
         self._server_socket_ready_event = ThreadingEvent()
         self._server_socket_name = None
 
@@ -1501,6 +1503,7 @@ class PyDB(object):
     def connect(self, host, port):
         if host:
             s = start_client(host, port)
+            self._client_socket = s
         else:
             s = start_server(port)
 
@@ -2547,6 +2550,10 @@ class PyDB(object):
             except:
                 pass
         finally:
+            if self._client_socket:
+                self._client_socket.close()
+                self._client_socket = None
+
             pydev_log.debug("PyDB.dispose_and_kill_all_pydevd_threads: finished")
 
     def prepare_to_run(self):


### PR DESCRIPTION
Backport of https://github.com/microsoft/debugpy/pull/1826, which has been released in the meantime.