### PR TITLE
add Python 3.14 compatible logic to check if a thread is alive

### DIFF
--- a/_pydev_bundle/pydev_is_thread_alive.py
+++ b/_pydev_bundle/pydev_is_thread_alive.py
@@ -5,7 +5,12 @@ from _pydev_bundle._pydev_saved_modules import threading
 # It is required to debug threads started by start_new_thread in Python 3.4
 _temp = threading.Thread()
 
-if hasattr(_temp, "_handle") and hasattr(_temp, "_started"):  # Python 3.13 and later has this
+if hasattr(_temp, "_os_thread_handle") and hasattr(_temp, "_started"):  # Python 3.14 has no `_handle`
+
+    def is_thread_alive(t):
+        return not t._os_thread_handle.is_done()
+
+elif hasattr(_temp, "_handle") and hasattr(_temp, "_started"):  # Python 3.13 and later has this
 
     def is_thread_alive(t):
         return not t._handle.is_done()

--- a/_pydevd_sys_monitoring/_pydevd_sys_monitoring.py
+++ b/_pydevd_sys_monitoring/_pydevd_sys_monitoring.py
@@ -13,6 +13,7 @@ from typing import Dict, Optional, Tuple, Any
 from os.path import basename, splitext
 
 from _pydev_bundle import pydev_log
+from _pydev_bundle.pydev_is_thread_alive import is_thread_alive
 from _pydevd_bundle import pydevd_dont_trace
 from _pydevd_bundle.pydevd_constants import (
     IS_PY313_OR_GREATER,
@@ -255,7 +256,6 @@ def _get_unhandled_exception_frame(exc, depth: int) -> Optional[FrameType]:
 #     cdef PyDBAdditionalThreadInfo additional_info
 #     thread: threading.Thread
 #     trace: bool
-#     _use_is_stopped: bool
 # ELSE
 class ThreadInfo:
     additional_info: PyDBAdditionalThreadInfo
@@ -276,8 +276,7 @@ class ThreadInfo:
         self.thread_ident = thread_ident
         self.additional_info = additional_info
         self.trace = trace
-        self._use_is_stopped = hasattr(thread, '_is_stopped')
-        
+
     # fmt: off
     # IFDEF CYTHON
     # cdef bint is_thread_alive(self):
@@ -285,10 +284,7 @@ class ThreadInfo:
     def is_thread_alive(self):
     # ENDIF
     # fmt: on
-        if self._use_is_stopped:
-            return not self.thread._is_stopped
-        else:
-            return not self.thread._handle.is_done()
+        return is_thread_alive(self.thread)
 
 
 class _DeleteDummyThreadOnDel:

--- a/_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.pyx
+++ b/_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.pyx
@@ -19,6 +19,7 @@ from typing import Dict, Optional, Tuple, Any
 from os.path import basename, splitext
 
 from _pydev_bundle import pydev_log
+from _pydev_bundle.pydev_is_thread_alive import is_thread_alive
 from _pydevd_bundle import pydevd_dont_trace
 from _pydevd_bundle.pydevd_constants import (
     IS_PY313_OR_GREATER,
@@ -247,7 +248,6 @@ cdef class ThreadInfo:
     cdef PyDBAdditionalThreadInfo additional_info
     thread: threading.Thread
     trace: bool
-    _use_is_stopped: bool
 # ELSE
 # class ThreadInfo:
 #     additional_info: PyDBAdditionalThreadInfo
@@ -268,8 +268,7 @@ cdef class ThreadInfo:
         self.thread_ident = thread_ident
         self.additional_info = additional_info
         self.trace = trace
-        self._use_is_stopped = hasattr(thread, '_is_stopped')
-        
+
     # fmt: off
     # IFDEF CYTHON -- DONT EDIT THIS FILE (it is automatically generated)
     cdef bint is_thread_alive(self):
@@ -277,10 +276,7 @@ cdef class ThreadInfo:
 #     def is_thread_alive(self):
     # ENDIF
     # fmt: on
-        if self._use_is_stopped:
-            return not self.thread._is_stopped
-        else:
-            return not self.thread._handle.is_done()
+        return is_thread_alive(self.thread)
 
 
 class _DeleteDummyThreadOnDel:


### PR DESCRIPTION
Hi Fabio, hope you are doing great.

Python 3.14.0b1 is available, and I'm experimenting with adopting it for my projects. Unfortunately, the debugger is not yet compatible with it. I'm currently looking into fixing it in PyCharm, and decided to first open a PR upstream. Would you consider contributions for Python 3.14 support, or is it too early?

Speaking of the changes ...

- `_handle` was renamed to `_os_thread_handle` in https://github.com/python/cpython/pull/132789
- I see you have a separate module for checking if the thread is alive - `_pydev_bundle/pydev_is_thread_alive.py`. Given that - was there a special reason why you didn't use it in `_pydevd_sys_monitoring/_pydevd_sys_monitoring.py`?
- I re-generated `_pydevd_sys_monitoring/_pydevd_sys_monitoring_cython.pyx` with `build_tools/generate_code.py`
- In `_pydev_bundle/pydev_is_thread_alive.py` you write "Hack for https://www.brainwy.com/tracker/PyDev/363", I wonder if this is still relevant in the Python >=3.8 world, perhaps the whole module could be drastically simplified

Thank you for your time.