### PR TITLE
bump Ubuntu version to 22.04 on CI

### DIFF
--- a/.github/workflows/pydevd-release-manylinux.yml
+++ b/.github/workflows/pydevd-release-manylinux.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pydevd-tests-python.yml
+++ b/.github/workflows/pydevd-tests-python.yml
@@ -31,7 +31,7 @@ jobs:
         include:
           - name: "ubuntu-pypy3"
             python: "pypy3.10"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             PYDEVD_USE_CYTHON: NO
 #           - name: "macos-py37-cython"
 #             python: "3.7"
@@ -39,7 +39,7 @@ jobs:
 #             PYDEVD_USE_CYTHON: YES
           - name: "ubuntu-py38-cython-checkbin"
             python: "3.8"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             PYDEVD_USE_CYTHON: YES
           - name: "windows-py39-cython"
             python: "3.9"
@@ -56,11 +56,11 @@ jobs:
             PYDEVD_USE_CYTHON: YES
           - name: "ubuntu-py311-cython"
             python: "3.11.0"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             PYDEVD_USE_CYTHON: YES
           - name: "ubuntu-py312-cython-checkbin"
             python: "3.12.0"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             PYDEVD_USE_CYTHON: YES
           - name: "windows-py312-cython-checkbin"
             python: "3.12"
@@ -68,7 +68,7 @@ jobs:
             PYDEVD_USE_CYTHON: YES
           - name: "ubuntu-py313-cython"
             python: "3.13"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             PYDEVD_USE_CYTHON: YES
           - name: "windows-py313-cython"
             python: "3.13"


### PR DESCRIPTION
20.04 is no longer supported by GitHub Actions, see https://github.com/actions/runner-images/issues/11101

The builds that use 20.04 are just cancelled, e.g., https://github.com/fabioz/PyDev.Debugger/actions/runs/15182838357/job/42710285578?pr=305