### PR TITLE
Add a pytorch tensor representation type

### DIFF
--- a/pydevd_plugins/extensions/types/pydevd_plugin_pytorch_types.py
+++ b/pydevd_plugins/extensions/types/pydevd_plugin_pytorch_types.py
@@ -1,0 +1,17 @@
+from _pydevd_bundle.pydevd_extension_api import StrPresentationProvider
+from .pydevd_helpers import find_mod_attr
+
+
+class PyTorchTensorFormStr:
+    def can_provide(self, type_object, type_name):
+        torch_tensor_class = find_mod_attr('torch', 'Tensor')
+        return torch_tensor_class is not None and issubclass(type_object, torch_tensor_class)
+
+    def get_str(self, val):
+        return "torch.Tensor [ %s , %s ]: %r" % (val.shape, val.device, val)
+
+
+import sys
+
+if not sys.platform.startswith("java"):
+    StrPresentationProvider.register(PyTorchTensorFormStr)


### PR DESCRIPTION
Displays the size and device of a torch.Tensor. 
Addressing https://github.com/microsoft/debugpy/issues/1525, 
https://github.com/microsoft/debugpy/issues/1191, etc.

Followup of https://github.com/fabioz/PyDev.Debugger/pull/288