### PR TITLE
Add settrace ppid kwarg

### DIFF
--- a/pydevd.py
+++ b/pydevd.py
@@ -2935,6 +2935,7 @@ def settrace(
     client_access_token=None,
     notify_stdin=True,
     protocol=None,
+    ppid=0,
     **kwargs,
 ):
     """Sets the tracing function with the pydev debug function and initializes needed facilities.
@@ -2994,6 +2995,11 @@ def settrace(
         When using in Eclipse the protocol should not be passed, but when used in VSCode
         or some other IDE/editor that accepts the Debug Adapter Protocol then 'dap' should
         be passed.
+
+    :param ppid:
+        Override the parent process id (PPID) for the current debugging session. This PPID is
+        reported to the debug client (IDE) and can be used to act like a child process of an
+        existing debugged process without being a child process.
     """
     if protocol and protocol.lower() == "dap":
         pydevd_defaults.PydevdCustomization.DEFAULT_PROTOCOL = pydevd_constants.HTTP_JSON_PROTOCOL
@@ -3022,6 +3028,7 @@ def settrace(
             client_access_token,
             __setup_holder__=__setup_holder__,
             notify_stdin=notify_stdin,
+            ppid=ppid,
         )
 
 
@@ -3045,6 +3052,7 @@ def _locked_settrace(
     client_access_token,
     __setup_holder__,
     notify_stdin,
+    ppid,
 ):
     if patch_multiprocessing:
         try:
@@ -3076,6 +3084,7 @@ def _locked_settrace(
                 "port": int(port),
                 "multiprocess": patch_multiprocessing,
                 "skip-notify-stdin": not notify_stdin,
+                pydevd_constants.ARGUMENT_PPID: ppid or 0,  # In case someone sets None, we use 0 as unset.
             }
             SetupHolder.setup = setup
 


### PR DESCRIPTION
Adds the ppid kwarg to settrace that allows the caller to customise the reported parent process id to a DAP client. This exposes the existing command line argument `--ppid` just through the Python API.

This is an attempt to upstream the changes proposed in https://github.com/microsoft/debugpy/pull/1920. Some background into why I am trying to add this to debugpy/pydevd is in https://github.com/microsoft/debugpy/issues/1918.