### PR TITLE
Add more flags to compile_linux script

### DIFF
--- a/pydevd_attach_to_process/linux_and_mac/compile_linux.sh
+++ b/pydevd_attach_to_process/linux_and_mac/compile_linux.sh
@@ -8,4 +8,4 @@ case $ARCH in
 esac
 
 SRC="$(dirname "$0")/.."
-g++ -std=c++11 -shared -fPIC -nostartfiles $SRC/linux_and_mac/attach.cpp -o $SRC/attach_linux_$SUFFIX.so
+g++ -std=c++11 -shared -fPIC -fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -nostartfiles $SRC/linux_and_mac/attach.cpp -o $SRC/attach_linux_$SUFFIX.so


### PR DESCRIPTION
This PR adds -fstack-protector-strong, -D_FORTIFY_SOURCE=2, and -O2 flags to strengthen the compiled binary. The changes were suggested by [BinSkim](https://github.com/microsoft/binskim).