### PR TITLE
Add linux ARM64 wheels

### DIFF
--- a/.github/workflows/pydevd-release-manylinux.yml
+++ b/.github/workflows/pydevd-release-manylinux.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        include:
+          - runs-on: ubuntu-latest
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            arch: aarch64
     steps:
       - uses: actions/checkout@v4
 
@@ -34,9 +38,11 @@ jobs:
         env:
           CIBW_SKIP: pp* cp36-* cp37-*
           CIBW_BUILD_VERBOSITY: 1
+          CIBW_ARCHS: ${{ matrix.arch }}
 
       - uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
           
       - name: Upload to PyPI .whl


### PR DESCRIPTION
From issue: https://github.com/fabioz/PyDev.Debugger/issues/317

*Motivation*

Enable the distribution of pre-compiled wheels for ARM64 Linux systems. With native ARM64 wheels, installation is faster and simpler for users.

*Description of Changes*

Add support for building Linux ARM64 wheels for the pydevd.

- Changed from os list to an include matrix with two configurations:
   - ubuntu-latest for x86_64 architecture (existing)
   - ubuntu-24.04-arm for aarch64 architecture

- Updated artifact upload to use unique names (wheels-x86_64 and wheels-aarch64)


*Testing*

Ran workflow on fork with PyPi upload omitted, and generated `wheels-aarch64` artifacts.
