### PR TITLE
fix: avoid splitting .zipx paths as zip files

### DIFF
--- a/pydevd_file_utils.py
+++ b/pydevd_file_utils.py
@@ -503,6 +503,9 @@ def _apply_func_and_normalize_case(filename, func, isabs, normalize_case, os_pat
         ind += 4
         zip_path = r[:ind]
         inner_path = r[ind:]
+        if inner_path and not inner_path.startswith(("!", "/", "\\")):
+            # Keep paths such as ".zipx/main.py" as regular filesystem paths.
+            inner_path = ""
         if inner_path.startswith("!"):
             # Note (fabioz): although I can replicate this by creating a file ending as
             # .zip! or .egg!, I don't really know what's the real-world case for this

--- a/tests_python/test_pydevd_file_utils.py
+++ b/tests_python/test_pydevd_file_utils.py
@@ -1,0 +1,12 @@
+import os
+
+import pydevd_file_utils
+
+
+def test_normalize_case_does_not_split_dot_zipx_directory(tmpdir):
+    zipx_dir = tmpdir.mkdir(".zipx")
+    filename = str(zipx_dir.join("main.py"))
+    zipx_dir.join("main.py").write("print('ok')\n")
+
+    expected = os.path.abspath(filename)
+    assert pydevd_file_utils._apply_func_and_normalize_case(filename, os.path.abspath, True, False) == expected


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Avoid treating directory names like `.zipx` as zip archive boundaries during path normalization.
- Keep the existing `.zip`, `.egg`, and `.egg!` archive path handling for actual archive-style inner paths.
- Add a focused regression test for an existing file under a `.zipx/` directory.

## Related Issues / Closes
Closes #265

## Testing
- Added the regression first and verified it failed before the source change: `_apply_func_and_normalize_case` returned `.zip/x/main.py` instead of `.zipx/main.py`.
- `python3 -m pytest tests_python/test_pydevd_file_utils.py -q` — passed
- `python3 -m py_compile pydevd_file_utils.py tests_python/test_pydevd_file_utils.py` — passed
- `git diff --check` — passed
- Also tried `python3 -m pytest tests_python/test_debugger.py::test_debug_zip_files -q`; a baseline run without this source change failed in this environment because the test dependency `untangle` is not installed, so this broader debugger integration test was not usable as validation here.

## AI assistance disclosure
This draft PR was prepared by Hermes Agent as an automated maintainer-assist change. A human maintainer should review before marking ready or merging.
