### PR TITLE
Fix GraalPy compatibility

### DIFF
--- a/_pydevd_bundle/pydevd_bytecode_utils.py
+++ b/_pydevd_bundle/pydevd_bytecode_utils.py
@@ -4,6 +4,11 @@ Bytecode analysing utils. Originally added for using in smart step into.
 Note: not importable from Python 2.
 """
 
+from _pydevd_bundle.pydevd_constants import IS_GRAALPY
+
+if IS_GRAALPY:
+    raise ImportError("Smart step into bytecode utilities are not available on GraalPy.")
+
 from _pydev_bundle import pydev_log
 from types import CodeType
 from _pydevd_frame_eval.vendored.bytecode.instr import _Variable, Label

--- a/_pydevd_bundle/pydevd_collect_bytecode_info.py
+++ b/_pydevd_bundle/pydevd_collect_bytecode_info.py
@@ -80,11 +80,21 @@ def debug(s):
 
 
 _Instruction = namedtuple("_Instruction", "opname, opcode, starts_line, argval, is_jump_target, offset, argrepr")
+_warned_dis_unavailable = False
 
 
 def iter_instructions(co):
-    iter_in = dis.Bytecode(co)
-    iter_in = list(iter_in)
+    global _warned_dis_unavailable
+
+    try:
+        iter_in = list(dis.Bytecode(co))
+    except NotImplementedError:
+        if not _warned_dis_unavailable:
+            _warned_dis_unavailable = True
+            # Log once because this is a supported-but-reduced mode on GraalPy: the
+            # debugger stays usable, but bytecode-derived helpers are unavailable.
+            pydev_log.info("Bytecode inspection is unavailable in this runtime; disabling dis-based debugger helpers.")
+        return
 
     bytecode_to_instruction = {}
     for instruction in iter_in:

--- a/_pydevd_bundle/pydevd_comm.py
+++ b/_pydevd_bundle/pydevd_comm.py
@@ -106,7 +106,10 @@ import itertools
 from urllib.parse import quote_plus, unquote_plus
 import pydevconsole
 from _pydevd_bundle import pydevd_vars, pydevd_io, pydevd_reload
-from _pydevd_bundle import pydevd_bytecode_utils
+try:
+    from _pydevd_bundle import pydevd_bytecode_utils
+except ImportError:
+    pydevd_bytecode_utils = None
 from _pydevd_bundle import pydevd_xml
 from _pydevd_bundle import pydevd_vm_type
 import sys

--- a/_pydevd_bundle/pydevd_constants.py
+++ b/_pydevd_bundle/pydevd_constants.py
@@ -62,6 +62,7 @@ USER_CODE_BASENAMES_STARTING_WITH = ("<ipython",)
 LIBRARY_CODE_BASENAMES_STARTING_WITH = ("<",)
 
 IS_CPYTHON = platform.python_implementation() == "CPython"
+IS_GRAALPY = sys.implementation.name == "graalpy"
 
 # Hold a reference to the original _getframe (because psyco will change that as soon as it's imported)
 IS_IRONPYTHON = sys.platform == "cli"


### PR DESCRIPTION
Fixes PyDev.Debugger compatibility with GraalPy, an alternative Python implementation. The main issue is that GraalPy uses a different bytecode format that is not exposed, so most of the `dis.*` APIs do not work (and cannot work) on GraalPy.