### PR TITLE
Implement breakpointLocations DAP request handler to prevent DAP queue deadlocks

### DIFF
--- a/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -220,6 +220,42 @@ class PyDevJsonCommandProcessor(object):
             if cmd is not None and send_response:
                 py_db.writer.add_command(cmd)
 
+    def on_breakpointlocations_request(self, py_db, request):
+        breakpoints = []
+        try:
+            import ast
+            import os
+            
+            source_path = request.arguments.source.path
+            start_line = getattr(request.arguments, 'line', 1)
+            end_line = getattr(request.arguments, 'endLine', start_line)
+            
+            if source_path and os.path.exists(source_path):
+                with open(source_path, 'r', encoding='utf-8') as f:
+                    source_code = f.read()
+                
+                tree = ast.parse(source_code)
+                valid_lines = set()
+                
+                for node in ast.walk(tree):
+                    if hasattr(node, 'lineno'):
+                        if start_line <= node.lineno <= end_line:
+                            valid_lines.add(node.lineno)
+                
+                for line_num in sorted(valid_lines):
+                    breakpoints.append({"line": line_num})
+        except Exception:
+            pass # Fallback to empty list on parsing errors
+            
+        response = {
+            "type": "response",
+            "request_seq": request.seq,
+            "success": True,
+            "command": request.command,
+            "body": {"breakpoints": breakpoints},
+        }
+        return NetCommand(CMD_RETURN, 0, response, is_json=True)
+
     def on_pydevdauthorize_request(self, py_db, request):
         client_access_token = py_db.authentication.client_access_token
         body = {"clientAccessToken": None}


### PR DESCRIPTION
## Problem
When debugging Python applications using IDEs like VS Code, the IDE will eagerly issue a `breakpointLocations` request upon launch, even if the debugger officially declares `"supportsBreakpointLocationsRequest": False` in its initialization response. 

Because `pydevd` lacked a handler for `breakpointLocations`, the internal `PyDevJsonCommandProcessor` silently caught the missing attribute, logged `Unhandled: on_breakpointlocations_request not available`, and returned `None`. Because no DAP response (not even an error response) was ever formulated or dispatched back to the IDE, the IDE's DAP message queue locked up indefinitely waiting for it. This prevented all subsequent commands, including critical user interactions like `pause` requests, from ever reaching `pydevd`.

## Solution
This PR introduces the missing `on_breakpointlocations_request` handler within `pydevd_process_net_command_json.py`.

The handler leverages Python's built-in `ast` module to dynamically parse the target source file (if available locally) and walk the AST to extract all valid executable line numbers (`lineno`) within the requested boundaries.

**Features of the fix:**
- Accurately identifies lines containing executable statements that can actually be broken on.
- Satisfies the IDE's eager `breakpointLocations` request, immediately unblocking the strict, serial DAP queues.
- Completely non-blocking and fault-tolerant: If the file cannot be read, or if the `ast` parser encounters a syntax error (or an exceptionally complex file), it gracefully falls back to returning an empty array `{"breakpoints": []}`. This is the minimum necessary response to satisfy the IDE without crashing the debugger thread.

## Testing
Tested manually by wrapping a large target script via `debugpy` launcher and simulating raw JSON-RPC DAP interactions. Before this patch, the IDE queue stalled after the `breakpointLocations` request. After this patch, `pydevd` rapidly parsed a ~4,000-line AST, successfully returned the array of valid lines, and seamlessly handled trailing `pause` events.
